### PR TITLE
[Feat/#43] Button 공통 컴포넌트 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
-import { createRequire } from "module";
 import globals from "globals";
+import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
@@ -37,7 +37,7 @@ const jsConfig = {
     "no-console": "warn",
     "no-extra-semi": "error",
     "no-unused-expressions": "error",
-    indent: ["error", 2],
+    indent: ["error", 2, { SwitchCase: 1, ignoredNodes: ["PropertyDefinition"] }],
     semi: ["warn", "always"],
     "no-undef": "error",
     "no-trailing-spaces": "warn",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import Button from "@components/commons/Button/Button";
 import router from "@routes/Router";
 import GlobalStyle from "@styles/global";
 import theme from "@styles/theme";
@@ -8,6 +9,13 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
+      <Button varient="primary" size="xlarge" isDisabled={true}>
+        테스트1
+      </Button>
+      <Button varient="primary" size="xlarge" isDisabled={false}>
+        테스트2
+      </Button>
+
       <RouterProvider router={router} />
     </ThemeProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,112 +6,18 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 
 function App() {
+  const handleOnClick = () => {
+    console.log("click!");
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      {/* Primary Buttons */}
-      <h2>Primary</h2>
-      <Button varient="primary" size="xlarge" isDisabled={false}>
-        Primary XL Enabled
+      <Button onClick={handleOnClick} varient="primary" size="xlarge" isDisabled={true}>
+        테스트1
       </Button>
-      <Button varient="primary" size="xlarge" isDisabled={true}>
-        Primary XL Disabled
-      </Button>
-      <Button varient="primary" size="large" isDisabled={false}>
-        Primary L Enabled
-      </Button>
-      <Button varient="primary" size="large" isDisabled={true}>
-        Primary L Disabled
-      </Button>
-      <Button varient="primary" size="medium" isDisabled={false}>
-        Primary M Enabled
-      </Button>
-      <Button varient="primary" size="medium" isDisabled={true}>
-        Primary M Disabled
-      </Button>
-      <Button varient="primary" size="small" isDisabled={false}>
-        Primary S Enabled
-      </Button>
-      <Button varient="primary" size="small" isDisabled={true}>
-        Primary S Disabled
-      </Button>
-      <Button varient="primary" size="xsmall" isDisabled={false}>
-        Primary XS Enabled
-      </Button>
-      <Button varient="primary" size="xsmall" isDisabled={true}>
-        Primary XS Disabled
-      </Button>
-
-      {/* Line Buttons */}
-      <h2>Line</h2>
-      <Button varient="line" size="xlarge" isDisabled={false}>
-        Line XL Enabled
-      </Button>
-      <Button varient="line" size="xlarge" isDisabled={true}>
-        Line XL Disabled
-      </Button>
-      <Button varient="line" size="large" isDisabled={false}>
-        Line L Enabled
-      </Button>
-      <Button varient="line" size="large" isDisabled={true}>
-        Line L Disabled
-      </Button>
-      <Button varient="line" size="medium" isDisabled={false}>
-        Line M Enabled
-      </Button>
-      <Button varient="line" size="medium" isDisabled={true}>
-        Line M Disabled
-      </Button>
-      <Button varient="line" size="small" isDisabled={false}>
-        Line S Enabled
-      </Button>
-      <Button varient="line" size="small" isDisabled={true}>
-        Line S Disabled
-      </Button>
-      <Button varient="line" size="xsmall" isDisabled={false}>
-        Line XS Enabled
-      </Button>
-      <Button varient="line" size="xsmall" isDisabled={true}>
-        Line XS Disabled
-      </Button>
-
-      {/* Gray Buttons */}
-      <h2>Gray</h2>
-      <Button varient="gray" size="xlarge" isDisabled={false}>
-        Gray XL Enabled
-      </Button>
-      <Button varient="gray" size="xlarge" isDisabled={true}>
-        Gray XL Disabled
-      </Button>
-      <Button varient="gray" size="large" isDisabled={false}>
-        Gray L Enabled
-      </Button>
-      <Button varient="gray" size="large" isDisabled={true}>
-        Gray L Disabled
-      </Button>
-      <Button varient="gray" size="medium" isDisabled={false}>
-        Gray M Enabled
-      </Button>
-      <Button varient="gray" size="medium" isDisabled={true}>
-        Gray M Disabled
-      </Button>
-      <Button varient="gray" size="small" isDisabled={false}>
-        Gray S Enabled
-      </Button>
-      <Button varient="gray" size="small" isDisabled={true}>
-        Gray S Disabled
-      </Button>
-      <Button varient="gray" size="xsmall" isDisabled={false}>
-        Gray XS Enabled
-      </Button>
-      <Button varient="gray" size="xsmall" isDisabled={true}>
-        Gray XS Disabled
-      </Button>
-
-      {/* Blue Buttons */}
-      <h2>Blue</h2>
-      <Button varient="blue" size="xlarge" isDisabled={false}>
-        Blue XL Enabled
+      <Button onClick={handleOnClick} varient="primary" size="xlarge" isDisabled={false}>
+        테스트2
       </Button>
 
       <RouterProvider router={router} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,12 @@ function App() {
       <Button onClick={handleOnClick} varient="primary" size="xlarge" isDisabled={false}>
         테스트2
       </Button>
+      <Button onClick={handleOnClick} varient="blue" size="small" isDisabled={true}>
+        테스트2
+      </Button>
+      <Button onClick={handleOnClick} varient="blue" size="xlarge" isDisabled={false}>
+        테스트2
+      </Button>
 
       <RouterProvider router={router} />
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,109 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <Button varient="primary" size="xlarge" isDisabled={true}>
-        테스트1
-      </Button>
+      {/* Primary Buttons */}
+      <h2>Primary</h2>
       <Button varient="primary" size="xlarge" isDisabled={false}>
-        테스트2
+        Primary XL Enabled
+      </Button>
+      <Button varient="primary" size="xlarge" isDisabled={true}>
+        Primary XL Disabled
+      </Button>
+      <Button varient="primary" size="large" isDisabled={false}>
+        Primary L Enabled
+      </Button>
+      <Button varient="primary" size="large" isDisabled={true}>
+        Primary L Disabled
+      </Button>
+      <Button varient="primary" size="medium" isDisabled={false}>
+        Primary M Enabled
+      </Button>
+      <Button varient="primary" size="medium" isDisabled={true}>
+        Primary M Disabled
+      </Button>
+      <Button varient="primary" size="small" isDisabled={false}>
+        Primary S Enabled
+      </Button>
+      <Button varient="primary" size="small" isDisabled={true}>
+        Primary S Disabled
+      </Button>
+      <Button varient="primary" size="xsmall" isDisabled={false}>
+        Primary XS Enabled
+      </Button>
+      <Button varient="primary" size="xsmall" isDisabled={true}>
+        Primary XS Disabled
+      </Button>
+
+      {/* Line Buttons */}
+      <h2>Line</h2>
+      <Button varient="line" size="xlarge" isDisabled={false}>
+        Line XL Enabled
+      </Button>
+      <Button varient="line" size="xlarge" isDisabled={true}>
+        Line XL Disabled
+      </Button>
+      <Button varient="line" size="large" isDisabled={false}>
+        Line L Enabled
+      </Button>
+      <Button varient="line" size="large" isDisabled={true}>
+        Line L Disabled
+      </Button>
+      <Button varient="line" size="medium" isDisabled={false}>
+        Line M Enabled
+      </Button>
+      <Button varient="line" size="medium" isDisabled={true}>
+        Line M Disabled
+      </Button>
+      <Button varient="line" size="small" isDisabled={false}>
+        Line S Enabled
+      </Button>
+      <Button varient="line" size="small" isDisabled={true}>
+        Line S Disabled
+      </Button>
+      <Button varient="line" size="xsmall" isDisabled={false}>
+        Line XS Enabled
+      </Button>
+      <Button varient="line" size="xsmall" isDisabled={true}>
+        Line XS Disabled
+      </Button>
+
+      {/* Gray Buttons */}
+      <h2>Gray</h2>
+      <Button varient="gray" size="xlarge" isDisabled={false}>
+        Gray XL Enabled
+      </Button>
+      <Button varient="gray" size="xlarge" isDisabled={true}>
+        Gray XL Disabled
+      </Button>
+      <Button varient="gray" size="large" isDisabled={false}>
+        Gray L Enabled
+      </Button>
+      <Button varient="gray" size="large" isDisabled={true}>
+        Gray L Disabled
+      </Button>
+      <Button varient="gray" size="medium" isDisabled={false}>
+        Gray M Enabled
+      </Button>
+      <Button varient="gray" size="medium" isDisabled={true}>
+        Gray M Disabled
+      </Button>
+      <Button varient="gray" size="small" isDisabled={false}>
+        Gray S Enabled
+      </Button>
+      <Button varient="gray" size="small" isDisabled={true}>
+        Gray S Disabled
+      </Button>
+      <Button varient="gray" size="xsmall" isDisabled={false}>
+        Gray XS Enabled
+      </Button>
+      <Button varient="gray" size="xsmall" isDisabled={true}>
+        Gray XS Disabled
+      </Button>
+
+      {/* Blue Buttons */}
+      <h2>Blue</h2>
+      <Button varient="blue" size="xlarge" isDisabled={false}>
+        Blue XL Enabled
       </Button>
 
       <RouterProvider router={router} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import Button from "@components/commons/Button/Button";
 import router from "@routes/Router";
 import GlobalStyle from "@styles/global";
 import theme from "@styles/theme";
@@ -6,26 +5,9 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 
 function App() {
-  const handleOnClick = () => {
-    console.log("click!");
-  };
-
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <Button onClick={handleOnClick} varient="primary" size="xlarge" isDisabled={true}>
-        테스트1
-      </Button>
-      <Button onClick={handleOnClick} varient="primary" size="xlarge" isDisabled={false}>
-        테스트2
-      </Button>
-      <Button onClick={handleOnClick} varient="blue" size="small" isDisabled={true}>
-        테스트2
-      </Button>
-      <Button onClick={handleOnClick} varient="blue" size="xlarge" isDisabled={false}>
-        테스트2
-      </Button>
-
       <RouterProvider router={router} />
     </ThemeProvider>
   );

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -6,19 +6,19 @@ interface DefaultBtnPropTypes {
 }
 
 const width = {
-  xlarge: "327px",
-  large: "279px",
-  medium: "158px",
-  small: "136px",
-  xsmall: "103px",
+  xlarge: "32.7rem",
+  large: "27.9rem",
+  medium: "15.8rem",
+  small: "13.6rem",
+  xsmall: "10.3rem",
 };
 
 const height = {
-  xlarge: "56px",
-  large: "46px",
-  medium: "46px",
-  small: "46px",
-  xsmall: "36px",
+  xlarge: "5.6rem",
+  large: "4.6rem",
+  medium: "4.6rem",
+  small: "4.6rem",
+  xsmall: "3.6rem",
 };
 
 const DefaultBtn = styled.button<DefaultBtnPropTypes>`
@@ -86,8 +86,8 @@ export const GrayButton = styled(DefaultBtn)`
 `;
 
 export const BlueButton = styled(DefaultBtn)`
-  width: 327px;
-  height: 56px;
+  width: 32.7rem;
+  height: 5.6rem;
 
   color: ${({ theme }) => theme.colors.white};
 

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -1,8 +1,8 @@
 import styled, { css } from "styled-components";
 
 interface DefaultBtnPropTypes {
-  size: "xlarge" | "large" | "medium" | "small" | "xsmall";
-  isDisabled?: boolean;
+  $size: "xlarge" | "large" | "medium" | "small" | "xsmall";
+  $isDisabled?: boolean;
 }
 
 const width = {
@@ -28,19 +28,19 @@ const DefaultBtn = styled.button<DefaultBtnPropTypes>`
 
   ${({ theme }) => theme.fonts["body2-normal-semi"]};
 
-  cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "cursor")};
+  cursor: ${({ $isDisabled }) => ($isDisabled ? "not-allowed" : "cursor")};
   border-radius: 6px;
-  ${({ size }) =>
-    size &&
+  ${({ $size }) =>
+    $size &&
     css`
-      width: ${width[size]};
-      height: ${height[size]};
+      width: ${width[$size]};
+      height: ${height[$size]};
     `};
 `;
 
 export const PrimaryButton = styled(DefaultBtn)`
-  ${({ isDisabled }) =>
-    isDisabled
+  ${({ $isDisabled }) =>
+    $isDisabled
       ? css`
           color: ${({ theme }) => theme.colors.pink_700};
 
@@ -54,8 +54,8 @@ export const PrimaryButton = styled(DefaultBtn)`
 `;
 
 export const LineButton = styled(DefaultBtn)`
-  ${({ isDisabled }) =>
-    isDisabled
+  ${({ $isDisabled }) =>
+    $isDisabled
       ? css`
           color: ${({ theme }) => theme.colors.pink_800};
 
@@ -71,8 +71,8 @@ export const LineButton = styled(DefaultBtn)`
 `;
 
 export const GrayButton = styled(DefaultBtn)`
-  ${({ isDisabled }) =>
-    isDisabled
+  ${({ $isDisabled }) =>
+    $isDisabled
       ? css`
           color: ${({ theme }) => theme.colors.gray_600};
 

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -1,0 +1,96 @@
+import theme from "@styles/theme";
+import styled, { css } from "styled-components";
+
+interface DefaultBtnPropTypes {
+  size: "xlarge" | "large" | "medium" | "small" | "xsmall";
+  isDisabled?: boolean;
+}
+
+const width = {
+  xlarge: "327px",
+  large: "279px",
+  medium: "158px",
+  small: "136px",
+  xsmall: "103px",
+};
+
+const height = {
+  xlarge: "56px",
+  large: "46px",
+  medium: "46px",
+  small: "46px",
+  xsmall: "36px",
+};
+
+const DefaultBtn = styled.button<DefaultBtnPropTypes>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: ${theme.fonts["body2-normal-semi"]};
+
+  cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "cursor")};
+  border-radius: 6px;
+  ${({ size }) =>
+    size &&
+    css`
+      width: ${width[size]};
+      height: ${height[size]};
+    `};
+`;
+
+export const PrimaryButton = styled(DefaultBtn)`
+  ${({ isDisabled }) =>
+    isDisabled
+      ? css`
+          color: ${theme.colors.pink_700};
+
+          background-color: ${theme.colors.pink_900};
+        `
+      : css`
+          color: ${theme.colors.white};
+
+          background-color: ${theme.colors.pink_400};
+        `}
+`;
+
+export const LineButton = styled(DefaultBtn)`
+  ${({ isDisabled }) =>
+    isDisabled
+      ? css`
+          color: ${theme.colors.pink_800};
+
+          background-color: ${theme.colors.gray_900};
+          border: 1px solid ${theme.colors.pink_800};
+        `
+      : css`
+          color: ${theme.colors.pink_400};
+
+          background-color: ${theme.colors.gray_900};
+          border: 1px solid ${theme.colors.pink_400};
+        `}
+`;
+
+export const GrayButton = styled(DefaultBtn)`
+  ${({ isDisabled }) =>
+    isDisabled
+      ? css`
+          color: ${theme.colors.gray_600};
+
+          background-color: ${theme.colors.gray_700};
+        `
+      : css`
+          color: ${theme.colors.white};
+
+          background-color: ${theme.colors.gray_700};
+        `}
+`;
+
+export const BlueButton = styled(DefaultBtn)`
+  width: 327px;
+  height: 56px;
+
+  color: ${theme.colors.white};
+
+  background-color: ${theme.colors.blue_400};
+`;

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -1,4 +1,3 @@
-import theme from "@styles/theme";
 import styled, { css } from "styled-components";
 
 interface DefaultBtnPropTypes {
@@ -27,7 +26,7 @@ const DefaultBtn = styled.button<DefaultBtnPropTypes>`
   align-items: center;
   justify-content: center;
 
-  font-size: ${theme.fonts["body2-normal-semi"]};
+  ${({ theme }) => theme.fonts["body2-normal-semi"]};
 
   cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "cursor")};
   border-radius: 6px;
@@ -43,14 +42,14 @@ export const PrimaryButton = styled(DefaultBtn)`
   ${({ isDisabled }) =>
     isDisabled
       ? css`
-          color: ${theme.colors.pink_700};
+          color: ${({ theme }) => theme.colors.pink_700};
 
-          background-color: ${theme.colors.pink_900};
+          background-color: ${({ theme }) => theme.colors.pink_900};
         `
       : css`
-          color: ${theme.colors.white};
+          color: ${({ theme }) => theme.colors.white};
 
-          background-color: ${theme.colors.pink_400};
+          background-color: ${({ theme }) => theme.colors.pink_400};
         `}
 `;
 
@@ -58,16 +57,16 @@ export const LineButton = styled(DefaultBtn)`
   ${({ isDisabled }) =>
     isDisabled
       ? css`
-          color: ${theme.colors.pink_800};
+          color: ${({ theme }) => theme.colors.pink_800};
 
-          background-color: ${theme.colors.gray_900};
-          border: 1px solid ${theme.colors.pink_800};
+          background-color: ${({ theme }) => theme.colors.gray_900};
+          border: 1px solid ${({ theme }) => theme.colors.pink_800};
         `
       : css`
-          color: ${theme.colors.pink_400};
+          color: ${({ theme }) => theme.colors.pink_400};
 
-          background-color: ${theme.colors.gray_900};
-          border: 1px solid ${theme.colors.pink_400};
+          background-color: ${({ theme }) => theme.colors.gray_900};
+          border: 1px solid ${({ theme }) => theme.colors.pink_400};
         `}
 `;
 
@@ -75,14 +74,14 @@ export const GrayButton = styled(DefaultBtn)`
   ${({ isDisabled }) =>
     isDisabled
       ? css`
-          color: ${theme.colors.gray_600};
+          color: ${({ theme }) => theme.colors.gray_600};
 
-          background-color: ${theme.colors.gray_700};
+          background-color: ${({ theme }) => theme.colors.gray_700};
         `
       : css`
-          color: ${theme.colors.white};
+          color: ${({ theme }) => theme.colors.white};
 
-          background-color: ${theme.colors.gray_700};
+          background-color: ${({ theme }) => theme.colors.gray_700};
         `}
 `;
 
@@ -90,7 +89,7 @@ export const BlueButton = styled(DefaultBtn)`
   width: 327px;
   height: 56px;
 
-  color: ${theme.colors.white};
+  color: ${({ theme }) => theme.colors.white};
 
-  background-color: ${theme.colors.blue_400};
+  background-color: ${({ theme }) => theme.colors.blue_400};
 `;

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -1,7 +1,9 @@
 import styled, { css } from "styled-components";
+import { ButtonSizeTypes, ButtonVariantTypes } from "./Button";
 
 interface DefaultBtnPropTypes {
-  $size: "xlarge" | "large" | "medium" | "small" | "xsmall";
+  $size: ButtonSizeTypes;
+  $variant: ButtonVariantTypes;
   $isDisabled?: boolean;
 }
 
@@ -21,7 +23,7 @@ const height = {
   xsmall: "3.6rem",
 };
 
-const DefaultBtn = styled.button<DefaultBtnPropTypes>`
+export const DefaultBtn = styled.button<DefaultBtnPropTypes>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,60 +38,56 @@ const DefaultBtn = styled.button<DefaultBtnPropTypes>`
       width: ${width[$size]};
       height: ${height[$size]};
     `};
-`;
 
-export const PrimaryButton = styled(DefaultBtn)`
-  ${({ $isDisabled }) =>
-    $isDisabled
-      ? css`
-          color: ${({ theme }) => theme.colors.pink_700};
+  ${({ $variant, $isDisabled }) => {
+    switch ($variant) {
+      case "primary":
+        return $isDisabled
+          ? css`
+              color: ${({ theme }) => theme.colors.pink_700};
 
-          background-color: ${({ theme }) => theme.colors.pink_900};
-        `
-      : css`
+              background-color: ${({ theme }) => theme.colors.pink_900};
+            `
+          : css`
+              color: ${({ theme }) => theme.colors.white};
+
+              background-color: ${({ theme }) => theme.colors.pink_400};
+            `;
+      case "line":
+        return $isDisabled
+          ? css`
+              color: ${({ theme }) => theme.colors.pink_800};
+
+              background-color: ${({ theme }) => theme.colors.gray_900};
+              border: 1px solid ${({ theme }) => theme.colors.pink_800};
+            `
+          : css`
+              color: ${({ theme }) => theme.colors.pink_400};
+
+              background-color: ${({ theme }) => theme.colors.gray_900};
+              border: 1px solid ${({ theme }) => theme.colors.pink_400};
+            `;
+      case "gray":
+        return $isDisabled
+          ? css`
+              color: ${({ theme }) => theme.colors.gray_600};
+
+              background-color: ${({ theme }) => theme.colors.gray_700};
+            `
+          : css`
+              color: ${({ theme }) => theme.colors.white};
+
+              background-color: ${({ theme }) => theme.colors.gray_700};
+            `;
+      case "blue":
+        return css`
+          width: 32.7rem;
+          height: 5.6rem;
+
           color: ${({ theme }) => theme.colors.white};
 
-          background-color: ${({ theme }) => theme.colors.pink_400};
-        `}
-`;
-
-export const LineButton = styled(DefaultBtn)`
-  ${({ $isDisabled }) =>
-    $isDisabled
-      ? css`
-          color: ${({ theme }) => theme.colors.pink_800};
-
-          background-color: ${({ theme }) => theme.colors.gray_900};
-          border: 1px solid ${({ theme }) => theme.colors.pink_800};
-        `
-      : css`
-          color: ${({ theme }) => theme.colors.pink_400};
-
-          background-color: ${({ theme }) => theme.colors.gray_900};
-          border: 1px solid ${({ theme }) => theme.colors.pink_400};
-        `}
-`;
-
-export const GrayButton = styled(DefaultBtn)`
-  ${({ $isDisabled }) =>
-    $isDisabled
-      ? css`
-          color: ${({ theme }) => theme.colors.gray_600};
-
-          background-color: ${({ theme }) => theme.colors.gray_700};
-        `
-      : css`
-          color: ${({ theme }) => theme.colors.white};
-
-          background-color: ${({ theme }) => theme.colors.gray_700};
-        `}
-`;
-
-export const BlueButton = styled(DefaultBtn)`
-  width: 32.7rem;
-  height: 5.6rem;
-
-  color: ${({ theme }) => theme.colors.white};
-
-  background-color: ${({ theme }) => theme.colors.blue_400};
+          background-color: ${({ theme }) => theme.colors.blue_400};
+        `;
+    }
+  }}
 `;

--- a/src/components/commons/Button/Button.styled.ts
+++ b/src/components/commons/Button/Button.styled.ts
@@ -1,3 +1,4 @@
+import { Generators } from "@styles/generator";
 import styled, { css } from "styled-components";
 import { ButtonSizeTypes, ButtonVariantTypes } from "./Button";
 
@@ -24,12 +25,8 @@ const height = {
 };
 
 export const DefaultBtn = styled.button<DefaultBtnPropTypes>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
+  ${Generators.flexGenerator("row", "center", "center")};
   ${({ theme }) => theme.fonts["body2-normal-semi"]};
-
   cursor: ${({ $isDisabled }) => ($isDisabled ? "not-allowed" : "cursor")};
   border-radius: 6px;
   ${({ $size }) =>

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -15,7 +15,13 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 //disabled는 버튼의 기본 속성(따라서 위의 interface에서 명시되어 있지는 않다.)
 const Button = ({ onClick, size, disabled, variant, children }: ButtonProps) => {
   return (
-    <S.DefaultBtn onClick={onClick} $size={size} $isDisabled={disabled} $variant={variant}>
+    <S.DefaultBtn
+      onClick={onClick}
+      $size={size}
+      disabled={disabled}
+      $isDisabled={disabled}
+      $variant={variant}
+    >
       {children}
     </S.DefaultBtn>
   );

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -1,18 +1,36 @@
+import { ReactNode } from "react";
 import * as S from "./Button.styled";
 
 export interface ButtonPropTypes {
   size: "xlarge" | "large" | "medium" | "small" | "xsmall";
   isDisabled?: boolean;
   varient: "primary" | "line" | "gray" | "blue";
+  children: ReactNode;
 }
 
-const Button = ({ size, isDisabled, varient }: ButtonPropTypes) => {
+const Button = ({ size, isDisabled, varient, children }: ButtonPropTypes) => {
   return (
     <>
-      {varient === "primary" && <S.PrimaryButton size={size} isDisabled={isDisabled} />}
-      {varient === "line" && <S.LineButton size={size} isDisabled={isDisabled} />}
-      {varient === "gray" && <S.GrayButton size={size} isDisabled={isDisabled} />}
-      {varient === "blue" && <S.BlueButton size={size} isDisabled={isDisabled} />}
+      {varient === "primary" && (
+        <S.PrimaryButton size={size} isDisabled={isDisabled}>
+          {children}
+        </S.PrimaryButton>
+      )}
+      {varient === "line" && (
+        <S.LineButton size={size} isDisabled={isDisabled}>
+          {children}
+        </S.LineButton>
+      )}
+      {varient === "gray" && (
+        <S.GrayButton size={size} isDisabled={isDisabled}>
+          {children}
+        </S.GrayButton>
+      )}
+      {varient === "blue" && (
+        <S.BlueButton size={size} isDisabled={isDisabled}>
+          {children}
+        </S.BlueButton>
+      )}
     </>
   );
 };

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -1,0 +1,20 @@
+import * as S from "./Button.styled";
+
+export interface ButtonPropTypes {
+  size: "xlarge" | "large" | "medium" | "small" | "xsmall";
+  isDisabled?: boolean;
+  varient: "primary" | "line" | "gray" | "blue";
+}
+
+const Button = ({ size, isDisabled, varient }: ButtonPropTypes) => {
+  return (
+    <>
+      {varient === "primary" && <S.PrimaryButton size={size} isDisabled={isDisabled} />}
+      {varient === "line" && <S.LineButton size={size} isDisabled={isDisabled} />}
+      {varient === "gray" && <S.GrayButton size={size} isDisabled={isDisabled} />}
+      {varient === "blue" && <S.BlueButton size={size} isDisabled={isDisabled} />}
+    </>
+  );
+};
+
+export default Button;

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -1,33 +1,50 @@
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 import * as S from "./Button.styled";
 
 export interface ButtonPropTypes {
   size: "xlarge" | "large" | "medium" | "small" | "xsmall";
   isDisabled?: boolean;
   varient: "primary" | "line" | "gray" | "blue";
-  children: ReactNode;
+  children: ReactNode; //자식 노드(텍스트)를 받기 위해 필수.
+  onClick: React.MouseEventHandler<HTMLButtonElement> | undefined; //MouseEvent와는 상이
 }
 
-const Button = ({ size, isDisabled, varient, children }: ButtonPropTypes) => {
+const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropTypes) => {
   return (
     <>
       {varient === "primary" && (
-        <S.PrimaryButton size={size} isDisabled={isDisabled}>
+        <S.PrimaryButton
+          onClick={isDisabled ? undefined : onClick}
+          size={size}
+          isDisabled={isDisabled}
+        >
           {children}
         </S.PrimaryButton>
       )}
       {varient === "line" && (
-        <S.LineButton size={size} isDisabled={isDisabled}>
+        <S.LineButton
+          onClick={isDisabled ? undefined : onClick}
+          size={size}
+          isDisabled={isDisabled}
+        >
           {children}
         </S.LineButton>
       )}
       {varient === "gray" && (
-        <S.GrayButton size={size} isDisabled={isDisabled}>
+        <S.GrayButton
+          onClick={isDisabled ? undefined : onClick}
+          size={size}
+          isDisabled={isDisabled}
+        >
           {children}
         </S.GrayButton>
       )}
       {varient === "blue" && (
-        <S.BlueButton size={size} isDisabled={isDisabled}>
+        <S.BlueButton
+          onClick={isDisabled ? undefined : onClick}
+          size={size}
+          isDisabled={isDisabled}
+        >
           {children}
         </S.BlueButton>
       )}

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -1,54 +1,23 @@
 import React, { ReactNode } from "react";
 import * as S from "./Button.styled";
 
-export interface ButtonPropTypes {
-  size: "xlarge" | "large" | "medium" | "small" | "xsmall";
-  isDisabled?: boolean;
-  variant: "primary" | "line" | "gray" | "blue";
+export type ButtonSizeTypes = "xlarge" | "large" | "medium" | "small" | "xsmall";
+export type ButtonVariantTypes = "primary" | "line" | "gray" | "blue";
+
+//React.ButtonHTMLAttributes는 버튼 속성에 집중하긴 했지만, 제네릭 타입이다.
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size: ButtonSizeTypes;
+  variant: ButtonVariantTypes;
   children: ReactNode; //자식 노드(텍스트)를 받기 위해 필수.
-  onClick: React.MouseEventHandler<HTMLButtonElement> | undefined; //MouseEvent와는 상이
+  onClick?: React.MouseEventHandler<HTMLButtonElement>; //MouseEvent와는 상이
 }
 
-const Button = ({ onClick, size, isDisabled, variant, children }: ButtonPropTypes) => {
+//disabled는 버튼의 기본 속성(따라서 위의 interface에서 명시되어 있지는 않다.)
+const Button = ({ onClick, size, disabled, variant, children }: ButtonProps) => {
   return (
-    <>
-      {variant === "primary" && (
-        <S.PrimaryButton
-          onClick={isDisabled ? undefined : onClick}
-          $size={size}
-          $isDisabled={isDisabled}
-        >
-          {children}
-        </S.PrimaryButton>
-      )}
-      {variant === "line" && (
-        <S.LineButton
-          onClick={isDisabled ? undefined : onClick}
-          $size={size}
-          $isDisabled={isDisabled}
-        >
-          {children}
-        </S.LineButton>
-      )}
-      {variant === "gray" && (
-        <S.GrayButton
-          onClick={isDisabled ? undefined : onClick}
-          $size={size}
-          $isDisabled={isDisabled}
-        >
-          {children}
-        </S.GrayButton>
-      )}
-      {variant === "blue" && (
-        <S.BlueButton
-          onClick={isDisabled ? undefined : onClick}
-          $size={size}
-          $isDisabled={isDisabled}
-        >
-          {children}
-        </S.BlueButton>
-      )}
-    </>
+    <S.DefaultBtn onClick={onClick} $size={size} $isDisabled={disabled} $variant={variant}>
+      {children}
+    </S.DefaultBtn>
   );
 };
 

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -4,15 +4,15 @@ import * as S from "./Button.styled";
 export interface ButtonPropTypes {
   size: "xlarge" | "large" | "medium" | "small" | "xsmall";
   isDisabled?: boolean;
-  varient: "primary" | "line" | "gray" | "blue";
+  variant: "primary" | "line" | "gray" | "blue";
   children: ReactNode; //자식 노드(텍스트)를 받기 위해 필수.
   onClick: React.MouseEventHandler<HTMLButtonElement> | undefined; //MouseEvent와는 상이
 }
 
-const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropTypes) => {
+const Button = ({ onClick, size, isDisabled, variant, children }: ButtonPropTypes) => {
   return (
     <>
-      {varient === "primary" && (
+      {variant === "primary" && (
         <S.PrimaryButton
           onClick={isDisabled ? undefined : onClick}
           $size={size}
@@ -21,7 +21,7 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
           {children}
         </S.PrimaryButton>
       )}
-      {varient === "line" && (
+      {variant === "line" && (
         <S.LineButton
           onClick={isDisabled ? undefined : onClick}
           $size={size}
@@ -30,7 +30,7 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
           {children}
         </S.LineButton>
       )}
-      {varient === "gray" && (
+      {variant === "gray" && (
         <S.GrayButton
           onClick={isDisabled ? undefined : onClick}
           $size={size}
@@ -39,7 +39,7 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
           {children}
         </S.GrayButton>
       )}
-      {varient === "blue" && (
+      {variant === "blue" && (
         <S.BlueButton
           onClick={isDisabled ? undefined : onClick}
           $size={size}

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -15,8 +15,8 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
       {varient === "primary" && (
         <S.PrimaryButton
           onClick={isDisabled ? undefined : onClick}
-          size={size}
-          isDisabled={isDisabled}
+          $size={size}
+          $isDisabled={isDisabled}
         >
           {children}
         </S.PrimaryButton>
@@ -24,8 +24,8 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
       {varient === "line" && (
         <S.LineButton
           onClick={isDisabled ? undefined : onClick}
-          size={size}
-          isDisabled={isDisabled}
+          $size={size}
+          $isDisabled={isDisabled}
         >
           {children}
         </S.LineButton>
@@ -33,8 +33,8 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
       {varient === "gray" && (
         <S.GrayButton
           onClick={isDisabled ? undefined : onClick}
-          size={size}
-          isDisabled={isDisabled}
+          $size={size}
+          $isDisabled={isDisabled}
         >
           {children}
         </S.GrayButton>
@@ -42,8 +42,8 @@ const Button = ({ onClick, size, isDisabled, varient, children }: ButtonPropType
       {varient === "blue" && (
         <S.BlueButton
           onClick={isDisabled ? undefined : onClick}
-          size={size}
-          isDisabled={isDisabled}
+          $size={size}
+          $isDisabled={isDisabled}
         >
           {children}
         </S.BlueButton>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,14 @@
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import svgr from "vite-plugin-svgr";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     svgr({
-      svgrOptions: {
+      svgrOpytions: {
         icon: true,
         memo: true,
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     react(),
     svgr({
-      svgrOpytions: {
+      svgrOptions: {
         icon: true,
         memo: true,
       },


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #43 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-  Button 공통 컴포넌트 추가
- onClick 연결 가능하도록 구현, prop으로 원하는 버튼 렌더링할 수 있도록 구현
- isDisabled = {true}일 경우, 클릭 못하는 표시가 나도록 커서 변경하도록 구현 & 실제로 onClick에 아무 함수도 할당되지 않도록 구현

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
사용 방법은 정말 간단합니다 !
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/30d57ca9-b06a-42bc-9e46-3994a9111794)
위 사진에서 빨간 네모칸 친 부분만 유의해서 보시면 됩니다. 
1. 우선 Button 컴포넌트를 import 해온다.
2. onClick, varient, size, isDisabled에 원하는 속성값을 할당해준다 (타입 정의해놓았으니, 아무거나 쳐보시면 어떤 속성값을 사용할 수 있는지 나옵니다!)
3. 버튼 컴포넌트 내부(자식 노드)에 텍스트 입력하면 버튼 네이밍까지 완료! 
- 참고로, Blue 버튼의 경우에는 size가 하나이므로 size를 어떻게 주든 동일한 크기의 버튼만 만들어집니다. 


모든 경우의 수를 테스트 해본 사진입니다.
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/dac72319-c691-4548-88fc-0695ffe6c740)
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/e70d7f2a-c8d8-4988-bb6d-fb188e2a833c)
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/d7e3e2ad-bbaa-4d50-ab44-e5c4441b25c9)
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/82411a4b-b4ac-4b55-937b-45c9c3b6a54c)


## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
SOPT 타입스크립트 세션(6주차)
https://www.howdy-mj.me/react/event-handling-in-react
https://smart-factory-lee-joon-ho.tistory.com/entry/React-%ED%95%A8%EC%88%98%ED%98%95-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8-%EC%83%9D%EC%84%B1-%EB%8B%A8%EC%B6%95%ED%82%A4-rafce-rfce-Extension
https://hianna.tistory.com/507