### PR TITLE
[Fix/#60] 모달 외부 영역 클릭시, 모달 닫는 로직 추가

### DIFF
--- a/src/components/commons/modal/Alert.tsx
+++ b/src/components/commons/modal/Alert.tsx
@@ -1,6 +1,7 @@
 import useModal from "@hooks/useModal";
 import { alertAtom } from "@stores/modal";
 import { useAtomValue } from "jotai";
+import React from "react";
 import Button from "../button/Button";
 import ModalTextBox from "./components/ModalTextBox";
 import ModalWrapper from "./components/ModalWrapper";
@@ -11,14 +12,15 @@ const Alert = () => {
 
   const { closeAlert } = useModal();
 
-  const handleOk = () => {
+  const handleOk = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation();
     okCallback?.();
     closeAlert();
   };
 
   if (isOpen) {
     return (
-      <ModalWrapper>
+      <ModalWrapper type="alert">
         <ModalTextBox title={title} subTitle={subTitle} />
 
         <Button size="large" variant="primary" onClick={handleOk}>

--- a/src/components/commons/modal/Confirm.tsx
+++ b/src/components/commons/modal/Confirm.tsx
@@ -24,7 +24,7 @@ const Confirm = () => {
 
   if (isOpen) {
     return (
-      <ModalWrapper>
+      <ModalWrapper type="confirm">
         <ModalTextBox title={title} subTitle={subTitle} />
 
         <S.ButtonWrapper>

--- a/src/components/commons/modal/components/ModalWrapper.styled.ts
+++ b/src/components/commons/modal/components/ModalWrapper.styled.ts
@@ -4,7 +4,7 @@ export const ModalWrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 100;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -15,6 +15,7 @@ export const ModalWrapper = styled.div`
 `;
 
 export const ModalContainer = styled.div`
+  z-index: 30;
   display: flex;
   flex-direction: column;
   gap: 3.2rem;

--- a/src/components/commons/modal/components/ModalWrapper.tsx
+++ b/src/components/commons/modal/components/ModalWrapper.tsx
@@ -1,14 +1,38 @@
-import React from "react";
+import useModal from "@hooks/useModal";
+import React, { useRef } from "react";
 import * as S from "./ModalWrapper.styled";
 
 interface ModalWrapperProps {
   children: React.ReactNode;
+  type: "alert" | "confirm" | "modal";
 }
 
-const ModalWrapper = ({ children }: ModalWrapperProps) => {
+const ModalWrapper = ({ children, type }: ModalWrapperProps) => {
+  const { closeAlert, closeConfirm } = useModal();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const closeModal = () => {
+    switch (type) {
+      case "alert":
+        closeAlert();
+        return;
+      case "confirm":
+        closeConfirm();
+        return;
+      default:
+        return;
+    }
+  };
+
+  const handleClickOutside = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      closeModal();
+    }
+  };
+
   return (
-    <S.ModalWrapper>
-      <S.ModalContainer>{children}</S.ModalContainer>
+    <S.ModalWrapper onClick={handleClickOutside}>
+      <S.ModalContainer ref={containerRef}>{children}</S.ModalContainer>
     </S.ModalWrapper>
   );
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #60 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 모달 외부 영역 클릭시, 모달 닫는 로직 추가

## 📢 To Reviewers

- 이전과 사용법은 동일합니다! 모달 외부 영역 클릭시, 모달 닫는 로직 추가하였습니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/TEAM-BEAT/BEAT-Client/assets/58854041/df786858-d631-4c0a-9a93-00afb7c496fd

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
