### PR TITLE
[Fix/#74] TextCap 조건 추가

### DIFF
--- a/src/components/commons/input/textField/TextField.tsx
+++ b/src/components/commons/input/textField/TextField.tsx
@@ -8,6 +8,7 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   narrow?: false | true;
   unit?: "time" | "ticket" | "amount"; // 단위 : "분", "매", "원"
   filter?: (value: string) => string;
+  cap?: false | true;
 }
 
 const TextField = ({
@@ -18,6 +19,7 @@ const TextField = ({
   narrow,
   unit,
   filter,
+  cap,
   ...rest
 }: TextFieldProps) => {
   const label = unit === "time" ? "분" : unit === "ticket" ? "매" : "원";
@@ -52,7 +54,7 @@ const TextField = ({
         {!narrow && !unit && value && <S.TextClear onClick={handleClearInput} />}
         {unit && <S.TextUnit>{label}</S.TextUnit>}
       </S.TextFieldWrapper>
-      {maxLength && <S.TextCap>{`${(value as string).length}/${maxLength}`}</S.TextCap>}
+      {maxLength && cap && <S.TextCap>{`${(value as string).length}/${maxLength}`}</S.TextCap>}
     </S.TextFieldLayout>
   );
 };

--- a/src/pages/test/TestPage.tsx
+++ b/src/pages/test/TestPage.tsx
@@ -7,6 +7,7 @@ import Spacing from "@components/commons/spacing/Spacing";
 import Stepper from "@components/commons/stepper/Stepper";
 import Toast from "@components/commons/toast/Toast";
 import useToast from "@hooks/useToast";
+import { numericFilter } from "@utils/useInputFilter";
 import { useState } from "react";
 
 const TestPage = () => {
@@ -29,12 +30,13 @@ const TestPage = () => {
   };
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "3rem", alignItems: "center" }}>
-      <div style={{ display: "flex", flexDirection: "column" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "3rem" }}>
         <TextField
           value={inputValue}
           onChangeValue={handleChangeInput}
-          maxLength={30}
-          placeholder="입력해주세요"
+          filter={numericFilter}
+          maxLength={4}
+          placeholder="비밀번호 숫자 4자리"
         />
         <TextArea
           value={inputAreaValue}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #74 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. TextCap 조건 추가
2. TextField prop 추가

## 📢 To Reviewers

- maxLength만 있으면 무조건 아래에 글자수가 떴는데, cap은 필요없는 input이 있어서 수정했습니다.
 ```tsx
<TextField
          value={inputValue}
          onChangeValue={handleChangeInput}
          filter={numericFilter}
          maxLength={4}
          placeholder="비밀번호 숫자 4자리"
 />
```
maxLength만 있으면 글자수 제한생기고 
`cap={true}`까지 추가해야 cap 생깁니다!!
## 📸 스크린샷
<img width="279" alt="image" src="https://github.com/TEAM-BEAT/BEAT-Client/assets/90364711/19431e4e-34c8-44e7-8d5f-50d6225de03b">

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
