### PR TITLE
[Refactor/#106] Navigation 공통 컴포넌트 리팩토링

### DIFF
--- a/src/components/commons/navigation/Navigation.tsx
+++ b/src/components/commons/navigation/Navigation.tsx
@@ -1,152 +1,90 @@
-import { NAVIGATION_STATE, NavigationState } from "@constants/navigationState";
-import useModal from "@hooks/useModal";
-import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { useHeader } from "@hooks/useHeader";
 import * as S from "./Navigation.styled";
 
 const Navigation = () => {
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-  const { openConfirm } = useModal();
+  const { header } = useHeader();
+  const { headerStyle, title, subText, leftOnClick, rightOnClick } = header;
 
-  const [headerPosition, setHeaderPosition] = useState<NavigationState>();
-  const [title, setTitle] = useState("");
-  const [subText, setSubText] = useState("");
-  // TODO: 전역상태로 관리?
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  //함수 연결은 거의 필수이므로, 경고 콘솔 띄워 디버깅 용이하도록 구성.
+  if (!leftOnClick) {
+    //만약 왼쪽 함수를 부여하지 않았다면
+    console.log("warn: 왼쪽 버튼 미연결");
+  }
+  if (!rightOnClick) {
+    //만약 오른쪽 함수를 부여하지 않았다면
+    console.log("warn: 오른쪽 버튼 미연결");
+  }
 
-  const onClickLogo = () => {
-    // TODO: 화면 맨 위로 스크롤? 어떤 액션할 지
-    navigate("/");
-  };
-
-  const onClickMenuBar = () => {
-    // TODO: 메뉴 연결
-    console.log("clicked menubar");
-  };
-
-  const onClickBack = () => {
-    openConfirm({
-      title: "정말 나가시겠습니까?",
-      subTitle: "지금 나가실 경우 작성하신 내용이 저장되지 않습니다.",
-      okText: "작성할게요",
-      okCallback: () => {
-        // TODO: 액션 추가
-        console.log("ok click");
-      },
-      noText: "나갈게요",
-      noCallback: () => {
-        // TODO: 액션 추가
-        console.log("no click");
-      },
-    });
-  };
-
-  const onClickTest = () => {
-    console.log("test Click");
-  };
-
-  useEffect(() => {
-    switch (true) {
-      case pathname === "/testpage":
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE_ICON);
-        setTitle("테스트 페이지");
-        setSubText("삭제");
-        break;
-      case pathname === "/":
-        setHeaderPosition(NAVIGATION_STATE.LOGO_HAMBURGAR);
-        break;
-      case pathname === "/register":
-        // TODO: 상세정보, 미리보기, 완료 따라 position, title 다르게
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE);
-        break;
-      case pathname.startsWith("/book"):
-        // TODO: 상세, 예매하기, 완료 따라 position, title 다르게
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE);
-        setTitle("공연 예약");
-        break;
-      case pathname === "/lookup":
-        // TODO: 회원, 비회원 로그인 여부에 따라 title 다르게
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE);
-        break;
-      case pathname === "/manage":
-        // TODO: 공연목록, 수정, 삭제 따라 position, title, subTitle 다르게
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE);
-        break;
-      case pathname === "/myregisteredshow":
-        setHeaderPosition(NAVIGATION_STATE.ICON_TITLE);
-        setTitle("내가 등록한 공연");
-        break;
-      default:
-        setTitle("");
-    }
-  }, [pathname]);
-
-  if (headerPosition === NAVIGATION_STATE.ICON_TITLE) {
+  if (headerStyle === NAVIGATION_STATE.ICON_TITLE) {
     return (
       <S.NavigationWrapper>
-        <S.NavigationLeftButton onClick={onClickBack} />
+        <S.NavigationLeftButton onClick={leftOnClick} />
         <S.NavigationTitle>{title}</S.NavigationTitle>
         <S.FragmentDiv />
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.TITLE_ICON) {
+  if (headerStyle === NAVIGATION_STATE.TITLE_ICON) {
     return (
       <S.NavigationWrapper>
         <S.FragmentDiv />
         <S.NavigationTitle>{title}</S.NavigationTitle>
-        <S.NavigationXButton onClick={onClickTest} />
+        <S.NavigationXButton onClick={rightOnClick} />
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.ICON_TITLE_ICON) {
+  if (headerStyle === NAVIGATION_STATE.ICON_TITLE_ICON) {
     return (
       <S.NavigationWrapper>
-        <S.NavigationLeftButton onClick={onClickTest} />
+        <S.NavigationLeftButton onClick={leftOnClick} />
         <S.NavigationTitle>{title}</S.NavigationTitle>
-        <S.NavigationXButton onClick={onClickTest} />
+        <S.NavigationXButton onClick={rightOnClick} />
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.ICON_TITLE_SUB_TEXT) {
+  if (headerStyle === NAVIGATION_STATE.ICON_TITLE_SUB_TEXT) {
     return (
       <S.NavigationWrapper>
-        <S.NavigationLeftButton onClick={onClickTest} />
+        <S.NavigationLeftButton onClick={leftOnClick} />
         <S.NavigationTitle>{title}</S.NavigationTitle>
-        <S.SubTextButton onClick={onClickTest}>{subText}</S.SubTextButton>
+        <S.SubTextButton onClick={rightOnClick}>{subText}</S.SubTextButton>
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.ICON) {
+  if (headerStyle === NAVIGATION_STATE.ICON) {
     return (
       <S.NavigationWrapper>
         <S.FragmentDiv />
-        <S.NavigationXButton onClick={onClickTest} />
+        <S.NavigationXButton onClick={rightOnClick} />
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.LOGO_HAMBURGAR) {
+  if (headerStyle === NAVIGATION_STATE.LOGO_HAMBURGAR) {
     return (
       <S.NavigationWrapper>
-        <S.Logo onClick={onClickLogo} />
-        <S.HamburgarButton onClick={onClickMenuBar} />
+        <S.Logo onClick={leftOnClick} />
+        <S.HamburgarButton onClick={rightOnClick} />
       </S.NavigationWrapper>
     );
   }
 
-  if (headerPosition === NAVIGATION_STATE.ICON_ICON) {
+  if (headerStyle === NAVIGATION_STATE.ICON_ICON) {
     return (
       <S.NavigationWrapper>
-        <S.NavigationLeftButton onClick={onClickTest} />
-        <S.NavigationXButton onClick={onClickTest} />
+        <S.NavigationLeftButton onClick={leftOnClick} />
+        <S.NavigationXButton onClick={rightOnClick} />
       </S.NavigationWrapper>
     );
+  }
+
+  if (!headerStyle) {
+    return null;
   }
 
   return <></>;

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,0 +1,9 @@
+import { headerAtom } from "@stores/header";
+import { useAtom } from "jotai";
+
+export const useHeader = () => {
+  //여기서 header는 header 설정을 위해 필요한 속성들을 담은 객체.
+  const [header, setHeader] = useAtom(headerAtom);
+
+  return { header, setHeader };
+};

--- a/src/pages/MyRegisterdShow/MyRegisterdShow.tsx
+++ b/src/pages/MyRegisterdShow/MyRegisterdShow.tsx
@@ -1,5 +1,7 @@
 import Button from "@components/commons/button/Button";
-import { useState } from "react";
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { useHeader } from "@hooks/useHeader";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import bannerNarrow from "../../assets/images/banner_narrow.png";
 import * as S from "./MyRegisterdShow.styled";
@@ -7,11 +9,24 @@ import RegisteredCard from "./components/RegisteredCard";
 import { MY_REGISTERED_SHOW, RegisteredObjProps } from "./constants/myRegisterShow";
 
 const MyRegisterdShow = () => {
+  const { setHeader } = useHeader();
   const navigate = useNavigate();
+
   //추후 공연등록하기 주소(채현) 나오면 변경 예정
-  const handleBtn = () => {
-    navigate("/");
+  const handleBackBtn = () => {
+    navigate(-1);
   };
+
+  //모든 페이지 컴포넌트는 반드시 헤더 설정하기 + useEffect, NAVIGATION_STATE 사용하기
+  useEffect(() => {
+    setHeader({
+      headerStyle: NAVIGATION_STATE.ICON_TITLE,
+      title: "내가 등록한 공연",
+      subText: "메롱",
+      leftOnClick: handleBackBtn,
+    });
+  }, [setHeader]);
+
   //추후 API에서 받아온 걸로 set할 예정
   const [showList, setShowList] = useState(MY_REGISTERED_SHOW.data);
   const [isNothing, setIsNothing] = useState(false);

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -1,4 +1,25 @@
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { useHeader } from "@hooks/useHeader";
+import { useEffect } from "react";
+
 const Lookup = () => {
+  const { setHeader } = useHeader();
+
+  const handleLeftBtn = () => {
+    alert("왼쪽 버튼 클릭!");
+  };
+  const handleRightBtn = () => {
+    alert("오른쪽 버튼 클릭!");
+  };
+  useEffect(() => {
+    setHeader({
+      headerStyle: NAVIGATION_STATE.ICON_TITLE_ICON,
+      title: "헤더 테스트!",
+      subText: "굿",
+      leftOnClick: handleLeftBtn,
+      rightOnClick: handleRightBtn,
+    });
+  }, [setHeader]);
   return <div>Lookup</div>;
 };
 

--- a/src/stores/header.ts
+++ b/src/stores/header.ts
@@ -1,0 +1,5 @@
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { HeaderProps } from "@typings/headerType";
+import { atom } from "jotai";
+
+export const headerAtom = atom<HeaderProps>({ headerStyle: NAVIGATION_STATE.ICON_TITLE_SUB_TEXT });

--- a/src/typings/headerType.ts
+++ b/src/typings/headerType.ts
@@ -3,7 +3,7 @@ import { NavigationState } from "@constants/navigationState";
 export interface HeaderProps {
   headerStyle: NavigationState;
   title?: string;
-  subTitle?: string;
+  subText?: string;
   leftOnClick?: () => void;
-  rightOnClikc?: () => void;
+  rightOnClick?: () => void;
 }

--- a/src/typings/headerType.ts
+++ b/src/typings/headerType.ts
@@ -1,0 +1,9 @@
+import { NavigationState } from "@constants/navigationState";
+
+export interface HeaderProps {
+  headerStyle: NavigationState;
+  title?: string;
+  subTitle?: string;
+  leftOnClick?: () => void;
+  rightOnClikc?: () => void;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #106 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 기존 Navigation 컴포넌트 파일에 직접 pathName과 콜백함수를 작성해주어야하는 번거로움을 줄여보고자 리팩토링 진행
- jotai를 활용한 전역 상태 관리를 통해, 하나의 Navigation 헤더의 스타일을 관리
- 각 페이지 내에서 useHeader() 훅을 사용하여 setHeader 함수를 받아오고, setHeader 함수에 헤더의 설정 관련된 내용을 담아 객체로 전달하면, 헤더가 해당 페이지에서 설정한 스타일로 렌더링되도록 구현


## 📢 To Reviewers
**사용 방법은 다음과 같습니다.**
각자 페이지에서 다음과 같은 코드를 작성하여 필요한 훅, 상수를 import 해옵니다. **(아래의 3개는 필수입니다.)**

```
import { NAVIGATION_STATE } from "@constants/navigationState";
import { useHeader } from "@hooks/useHeader";
import { useEffect } from "react";
```
그리고, 아래와 같이 setHeader 함수를 받아옵니다 !
`const { setHeader } = useHeader();
`
그 후, 연결할 콜백 함수를 작성합니다. 왼쪽, 오른쪽 최소 0개 ~최대 2개가 필요합니다. 
(어차피 헤더엔 최대 2개의 함수만 연결됨)

```
const handleLeftBtn = () => {
    alert("왼쪽 버튼 클릭!");
  };
  const handleRightBtn = () => {
    alert("오른쪽 버튼 클릭!");
  };
```

마지막으로, **반드시** **useEffect를 사용하여 setHeader 함수**에 적절한 설정들을 담은 객체를 prop으로 넘깁니다.
headerStyle 은 필수 속성이고, title, subText, leftOnClick, rightOnClick은 선택 속성입니다. 
headerStyled의 경우 위에서 import 해온 상수 객체 NAVIGATION_STATE 을 활용하여 값을 세팅하는 것을 추천합니다.

```
useEffect(() => {
    setHeader({
      headerStyle: NAVIGATION_STATE.ICON_TITLE_ICON,
      title: "헤더 테스트!",
      subText: "굿",
      leftOnClick: handleLeftBtn,
      rightOnClick: handleRightBtn,
    });
  }, [setHeader]);
```

참고로 의존성 배열에는 아무것도 넣지 않거나, setHeader 함수만 넣도록 합니다.
(마운트 될 때만 헤더가 해당 페이지에 맞게 세팅되도록 해야 합니다. 또한, useEffect를 사용하지 않을 경우 렌더링이 반복적으로 일어나서 결국 성능 최적화에 방해되기도 하고, 애초에 에러가 발생하여 렌더링이 안됩니다.)


## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/61fbb4c4-75e0-4766-a46f-652ab661c5ed)

다음은 함수도 연결한 예시입니다.
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/7c66d56b-9625-485d-9b52-effd41ed7e16)
![image](https://github.com/TEAM-BEAT/BEAT-Client/assets/155794105/ee7a5e46-26d7-410c-991d-155c3737fdcd)



## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
