### PR TITLE
[Feat/#146] 예매 상세, 예매 페이지 자잘한 사항 수정

### DIFF
--- a/src/components/commons/bottomSheet/actionsBottomSheet/ActionBottomSheet.tsx
+++ b/src/components/commons/bottomSheet/actionsBottomSheet/ActionBottomSheet.tsx
@@ -53,10 +53,12 @@ const ActionBottomSheet = ({
   return (
     <S.ActionBottomSheetWrapper $isOpen={isOpen} onClick={handleWrapperClick}>
       <BottomSheet isOpen={isOpen} title={title}>
-        <ContextBox {...rest}>
-          <S.SubTitle>{subTitle}</S.SubTitle>
-          {innerChildren}
-        </ContextBox>
+        {innerChildren.length > 0 && (
+          <ContextBox {...rest}>
+            <S.SubTitle>{subTitle}</S.SubTitle>
+            {innerChildren}
+          </ContextBox>
+        )}
         {outerChildren}
       </BottomSheet>
     </S.ActionBottomSheetWrapper>

--- a/src/components/commons/button/Button.tsx
+++ b/src/components/commons/button/Button.tsx
@@ -19,6 +19,7 @@ const Button = ({
   disabled,
   variant = "primary",
   children,
+  ...props
 }: ButtonProps) => {
   return (
     <S.DefaultBtn
@@ -27,6 +28,7 @@ const Button = ({
       disabled={disabled}
       $isDisabled={disabled}
       $variant={variant}
+      {...props}
     >
       {children}
     </S.DefaultBtn>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,8 +9,6 @@ const Layout = () => {
       <Main>
         <Outlet />
       </Main>
-
-      {/* TODO: footer 추가 */}
     </div>
   );
 };

--- a/src/pages/book/Book.tsx
+++ b/src/pages/book/Book.tsx
@@ -3,8 +3,10 @@ import ViewBottomSheet from "@components/commons/bottomSheet/viewBottomSheet/Vie
 import Button from "@components/commons/button/Button";
 import Context from "@components/commons/contextBox/Context";
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { useHeader } from "@hooks/useHeader";
 import * as S from "./Book.styled";
 import BookerInfo from "./components/bookerInfo/BookerInfo";
 import Count from "./components/count/Count";
@@ -16,11 +18,22 @@ import { BOOK_DETAIL_INFO } from "./constants/dummy";
 import { FormData } from "./typings/formData";
 
 const Book = () => {
+  const navigate = useNavigate();
   const { performanceId } = useParams<{ performanceId: string }>();
 
   // TODO: 회원/비회원 여부
-  // navigate 할 때 state로 넘기기 ?
+  const { setHeader } = useHeader();
   const isNonMember = true;
+
+  useEffect(() => {
+    setHeader({
+      headerStyle: NAVIGATION_STATE.ICON_TITLE_SUB_TEXT,
+      title: "예매하기",
+      leftOnClick: () => {
+        navigate(`/gig/${performanceId}`);
+      },
+    });
+  }, []);
 
   const [detail, setDetail] = useState(BOOK_DETAIL_INFO);
   const [selectedValue, setSelectedValue] = useState<number>();

--- a/src/pages/book/Book.tsx
+++ b/src/pages/book/Book.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader } from "@hooks/useHeader";
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 import * as S from "./Book.styled";
 import BookerInfo from "./components/bookerInfo/BookerInfo";
 import Count from "./components/count/Count";
@@ -121,11 +122,25 @@ const Book = () => {
         bookerName: bookerInfo.bookerName,
         bookerPhoneNumber: bookerInfo.bookerPhoneNumber,
       } as FormData;
-
-      console.log(formData);
     }
 
-    // TODO: 완료 페이지로 navigate
+    // TODO: response로 변경
+    console.log(formData, {
+      state: {
+        bankName: "농협",
+        accountNumber: "3561202376833",
+        totalPaymentAmount: formData.totalPaymentAmount,
+      },
+    });
+
+    // TODO: 요청 성공 시, 완료 페이지로 navigate
+    navigate("/book/complete", {
+      state: {
+        bankName: "농협",
+        accountNumber: "3561202376833",
+        totalPaymentAmount: formData.totalPaymentAmount,
+      },
+    });
   };
 
   useEffect(() => {
@@ -152,7 +167,7 @@ const Book = () => {
   return (
     <S.ContentWrapper>
       <Info
-        genre={detail.genre}
+        genre={detail.genre as SHOW_TYPE_KEY}
         title={detail.performanceTitle}
         teamName={detail.performanceTeamName}
         venue={detail.performanceVenue}

--- a/src/pages/book/components/count/Count.tsx
+++ b/src/pages/book/components/count/Count.tsx
@@ -29,7 +29,7 @@ const Count = ({
             )}
           </div>
 
-          <Stepper max={3} round={round} onMinusClick={onMinusClick} onPlusClick={onPlusClick} />
+          <Stepper max={10} round={round} onMinusClick={onMinusClick} onPlusClick={onPlusClick} />
         </S.Box>
       </S.Container>
       <div>

--- a/src/pages/book/components/info/Info.tsx
+++ b/src/pages/book/components/info/Info.tsx
@@ -1,10 +1,12 @@
 import { IconTime, IcOutlinePlace } from "@assets/svgs";
 import Spacing from "@components/commons/spacing/Spacing";
 import IconText from "@pages/gig/components/iconText/IconText";
+import ShowType from "@pages/gig/components/showType/ShowType";
+import { SHOW_TYPE, SHOW_TYPE_KEY, ShowTypes } from "@pages/gig/constants";
 import * as S from "./Info.styled";
 
 interface InfoProps {
-  genre: string;
+  genre: SHOW_TYPE_KEY;
   title: string;
   teamName: string;
   venue: string;
@@ -12,14 +14,15 @@ interface InfoProps {
 }
 
 const Info = ({ genre, title, teamName, venue, period }: InfoProps) => {
+  const getShowTypeText = (key: SHOW_TYPE_KEY): ShowTypes => SHOW_TYPE[key];
+
   return (
     <S.InfoContainer>
       <S.InfoTop>
         <S.InfoPoster $imgsrc={"src/pages/MyRegisterdShow/constants/silkagel.png"} />
 
         <S.InfoTextBox>
-          {/* TODO: genre에 따라 view 변경 */}
-          <S.InfoType>{genre}</S.InfoType>
+          <ShowType type={getShowTypeText(genre)} />
           <Spacing marginBottom="0.2" />
           <S.InfoTitle>{title}</S.InfoTitle>
           <Spacing marginBottom="5.2" />

--- a/src/pages/gig/Gig.styled.ts
+++ b/src/pages/gig/Gig.styled.ts
@@ -16,6 +16,7 @@ export const ButtonWrapper = styled.div`
 export const FooterContainer = styled.div`
   position: sticky;
   bottom: 0;
+  z-index: 2;
   padding: 2.4rem;
 
   background-color: ${({ theme }) => theme.colors.gray_900};

--- a/src/pages/gig/Gig.styled.ts
+++ b/src/pages/gig/Gig.styled.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 2.4rem;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+`;
+
+export const FooterContainer = styled.div`
+  position: sticky;
+  bottom: 0;
+  padding: 2.4rem;
+
+  background-color: ${({ theme }) => theme.colors.gray_900};
+`;

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -1,5 +1,9 @@
+import ActionBottomSheet from "@components/commons/bottomSheet/actionsBottomSheet/ActionBottomSheet";
+import OuterLayout from "@components/commons/bottomSheet/OuterLayout";
 import Button from "@components/commons/button/Button";
-import { useState } from "react";
+import { NAVIGATION_STATE } from "@constants/navigationState";
+import { useHeader } from "@hooks/useHeader";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import Content from "./components/content/Content";
@@ -8,12 +12,33 @@ import { SHOW_DETAIL_INFO } from "./constants";
 
 const Gig = () => {
   const navigate = useNavigate();
+  const { setHeader } = useHeader();
+
+  useEffect(() => {
+    setHeader({
+      headerStyle: NAVIGATION_STATE.ICON_TITLE_SUB_TEXT,
+      title: detail.performanceTitle,
+      leftOnClick: () => {
+        navigate("/main");
+      },
+    });
+  }, []);
+
   // TODO: performanceId로 상세 정보 조회(GET)
   const { performanceId } = useParams<{ performanceId: string }>();
   const [detail, setDetail] = useState(SHOW_DETAIL_INFO);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const handleBookClick = () => {
+    setIsSheetOpen(true);
+  };
+
+  const handleSheetClose = () => {
+    setIsSheetOpen(false);
+  };
 
   return (
-    <div>
+    <ContentWrapper>
       <ShowInfo
         posterImage={detail.posterImage}
         title={detail.performanceTitle}
@@ -33,13 +58,37 @@ const Gig = () => {
       />
       <FooterContainer>
         {/* TODO: 토큰 여부에 따라서 리다이렉트 */}
-        <Button onClick={() => navigate("/book/1")}>예매하기</Button>
+        <Button onClick={handleBookClick}>예매하기</Button>
       </FooterContainer>
-    </div>
+
+      <ActionBottomSheet
+        isOpen={isSheetOpen}
+        onClickOutside={handleSheetClose}
+        title="로그인 후 예매하시겠어요?"
+        alignItems="center"
+        padding="2rem 2rem 2.4rem 2rem"
+      >
+        <OuterLayout margin="1.6rem 0 0 0">
+          <Button variant="primary" size="xlarge">
+            확인했어요
+          </Button>
+          <Button variant="primary" size="xlarge">
+            확인했어요
+          </Button>
+        </OuterLayout>
+      </ActionBottomSheet>
+    </ContentWrapper>
   );
 };
 
 export default Gig;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 2.4rem;
+`;
 
 const FooterContainer = styled.div`
   position: sticky;

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -3,16 +3,18 @@ import OuterLayout from "@components/commons/bottomSheet/OuterLayout";
 import Button from "@components/commons/button/Button";
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader } from "@hooks/useHeader";
+import { requestKakaoLogin } from "@utils/kakaoLogin";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import styled from "styled-components";
 import Content from "./components/content/Content";
 import ShowInfo from "./components/showInfo/ShowInfo";
 import { SHOW_DETAIL_INFO } from "./constants";
+import * as S from "./Gig.styled";
 
 const Gig = () => {
   const navigate = useNavigate();
   const { setHeader } = useHeader();
+  const isLoggedIn = false;
 
   useEffect(() => {
     setHeader({
@@ -30,15 +32,21 @@ const Gig = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const handleBookClick = () => {
+    /* TODO: 토큰 여부에 따라서 리다이렉트 */
+
+    if (isLoggedIn) {
+      navigate(`/book/${performanceId}`);
+      return;
+    }
+
     setIsSheetOpen(true);
   };
 
   const handleSheetClose = () => {
     setIsSheetOpen(false);
   };
-
   return (
-    <ContentWrapper>
+    <S.ContentWrapper>
       <ShowInfo
         posterImage={detail.posterImage}
         title={detail.performanceTitle}
@@ -56,10 +64,9 @@ const Gig = () => {
         castList={detail.castList}
         staffList={detail.staffList}
       />
-      <FooterContainer>
-        {/* TODO: 토큰 여부에 따라서 리다이렉트 */}
+      <S.FooterContainer>
         <Button onClick={handleBookClick}>예매하기</Button>
-      </FooterContainer>
+      </S.FooterContainer>
 
       <ActionBottomSheet
         isOpen={isSheetOpen}
@@ -69,31 +76,23 @@ const Gig = () => {
         padding="2rem 2rem 2.4rem 2rem"
       >
         <OuterLayout margin="1.6rem 0 0 0">
-          <Button variant="primary" size="xlarge">
-            확인했어요
-          </Button>
-          <Button variant="primary" size="xlarge">
-            확인했어요
-          </Button>
+          <S.ButtonWrapper>
+            <Button
+              variant="primary"
+              size="xlarge"
+              style={{ backgroundColor: "#FEE500", color: "#0F0F0F" }}
+              onClick={requestKakaoLogin}
+            >
+              카카오 로그인
+            </Button>
+            <Button variant="gray" size="xlarge" onClick={() => navigate(`/book/${performanceId}`)}>
+              비회원 예매
+            </Button>
+          </S.ButtonWrapper>
         </OuterLayout>
       </ActionBottomSheet>
-    </ContentWrapper>
+    </S.ContentWrapper>
   );
 };
 
 export default Gig;
-
-export const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0 2.4rem;
-`;
-
-const FooterContainer = styled.div`
-  position: sticky;
-  bottom: 0;
-  padding: 2.4rem;
-
-  background-color: ${({ theme }) => theme.colors.gray_900};
-`;

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Content from "./components/content/Content";
 import ShowInfo from "./components/showInfo/ShowInfo";
-import { SHOW_DETAIL_INFO } from "./constants";
+import { SHOW_DETAIL_INFO, SHOW_TYPE_KEY } from "./constants";
 import * as S from "./Gig.styled";
 
 const Gig = () => {
@@ -49,6 +49,7 @@ const Gig = () => {
     <S.ContentWrapper>
       <ShowInfo
         posterImage={detail.posterImage}
+        genre={detail.genre as SHOW_TYPE_KEY}
         title={detail.performanceTitle}
         price={detail.ticketPrice}
         venue={detail.performanceVenue}

--- a/src/pages/gig/components/makerIntroduce/MakerIntroduce.styled.ts
+++ b/src/pages/gig/components/makerIntroduce/MakerIntroduce.styled.ts
@@ -30,3 +30,11 @@ export const TeamPeopleCardWrapper = styled.section`
 
   row-gap: 2rem;
 `;
+
+export const NoContentBox = styled.p`
+  padding: 2.6rem 0;
+
+  color: ${({ theme }) => theme.colors.gray_500};
+  ${({ theme }) => theme.fonts["body2-normal-medi"]};
+  text-align: center;
+`;

--- a/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
+++ b/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
@@ -9,41 +9,45 @@ interface MakerIntroduceProps {
 }
 
 const MakerIntroduce = ({ teamName, castList, staffList }: MakerIntroduceProps) => {
+  console.log(castList);
   return (
     <S.Wrapper>
       <S.Title>{teamName}</S.Title>
       <S.MakerInfoContainer>
         <S.MakerInfoTitle>출연진</S.MakerInfoTitle>
-        {/* TODO: 출연진 없을 떄 보여줄 컴포넌트 추가 */}
-        <S.TeamPeopleCardWrapper>
-          {castList.map((cast, i) => (
-            <PeopleCard
-              key={`${cast.castId}-${i}`}
-              photo={cast.castPhoto}
-              role={cast.castRole}
-              name={cast.castName}
-            />
-          ))}
-        </S.TeamPeopleCardWrapper>
+        {castList.length > 0 ? (
+          <S.TeamPeopleCardWrapper>
+            {castList.map((cast, i) => (
+              <PeopleCard
+                key={`${cast.castId}-${i}`}
+                photo={cast.castPhoto}
+                role={cast.castRole}
+                name={cast.castName}
+              />
+            ))}
+          </S.TeamPeopleCardWrapper>
+        ) : (
+          <S.NoContentBox>등록된 메이커 정보가 없어요.</S.NoContentBox>
+        )}
       </S.MakerInfoContainer>
 
-      {staffList.length > 0 && (
-        <>
-          <S.MakerInfoContainer>
-            <S.MakerInfoTitle>스태프</S.MakerInfoTitle>
-            <S.TeamPeopleCardWrapper>
-              {staffList.map((staff, i) => (
-                <PeopleCard
-                  key={`${staff.staffId}-${i}`}
-                  photo={staff.staffPhoto}
-                  role={staff.staffRole}
-                  name={staff.staffName}
-                />
-              ))}
-            </S.TeamPeopleCardWrapper>
-          </S.MakerInfoContainer>
-        </>
-      )}
+      <S.MakerInfoContainer>
+        <S.MakerInfoTitle>스태프</S.MakerInfoTitle>
+        {staffList.length > 0 ? (
+          <S.TeamPeopleCardWrapper>
+            {staffList.map((staff, i) => (
+              <PeopleCard
+                key={`${staff.staffId}-${i}`}
+                photo={staff.staffPhoto}
+                role={staff.staffRole}
+                name={staff.staffName}
+              />
+            ))}
+          </S.TeamPeopleCardWrapper>
+        ) : (
+          <S.NoContentBox>등록된 메이커 정보가 없어요.</S.NoContentBox>
+        )}
+      </S.MakerInfoContainer>
     </S.Wrapper>
   );
 };

--- a/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
+++ b/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
@@ -45,7 +45,7 @@ const MakerIntroduce = ({ teamName, castList, staffList }: MakerIntroduceProps) 
             ))}
           </S.TeamPeopleCardWrapper>
         ) : (
-          <S.NoContentBox>등록된 메이커 정보가 없어요.</S.NoContentBox>
+          <S.NoContentBox>등록된 스태프 정보가 없어요.</S.NoContentBox>
         )}
       </S.MakerInfoContainer>
     </S.Wrapper>

--- a/src/pages/gig/components/showInfo/ShowInfo.tsx
+++ b/src/pages/gig/components/showInfo/ShowInfo.tsx
@@ -1,6 +1,7 @@
 import { IconTime, IcOutlinePlace } from "@assets/svgs";
+import { SHOW_TYPE, SHOW_TYPE_KEY, ShowTypes } from "@pages/gig/constants";
 import IconText from "../iconText/IconText";
-import ShowTypes from "../showType/ShowType";
+import ShowType from "../showType/ShowType";
 import * as S from "./ShowInfo.styled";
 
 type SchelduleListType = {
@@ -11,6 +12,7 @@ type SchelduleListType = {
 
 interface ShowInfoProps {
   posterImage: string;
+  genre: SHOW_TYPE_KEY;
   title: string;
   price: number | null;
   venue: string;
@@ -21,6 +23,7 @@ interface ShowInfoProps {
 
 const ShowInfo = ({
   posterImage,
+  genre,
   title,
   price,
   venue,
@@ -28,10 +31,12 @@ const ShowInfo = ({
   runningTime,
   scheduleList,
 }: ShowInfoProps) => {
+  const getShowTypeText = (key: SHOW_TYPE_KEY): ShowTypes => SHOW_TYPE[key];
+
   return (
     <S.ShowInfoWrapper>
       <S.Poster $imgsrc={posterImage} />
-      <ShowTypes type="밴드" />
+      <ShowType type={getShowTypeText(genre)} />
       <S.Title>{title}</S.Title>
       <div>
         <S.Price>{price}</S.Price>

--- a/src/pages/gig/components/showType/ShowType.styled.ts
+++ b/src/pages/gig/components/showType/ShowType.styled.ts
@@ -3,7 +3,6 @@ import styled from "styled-components";
 export const ShowTypeWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
   margin-bottom: 0.4rem;
 `;
 

--- a/src/pages/gig/components/showType/ShowType.styled.ts
+++ b/src/pages/gig/components/showType/ShowType.styled.ts
@@ -10,12 +10,13 @@ export const ShowTypeWrapper = styled.div`
 export const ShowTypeIcon = styled.span`
   width: 1.6rem;
   height: 1.6rem;
-  margin-right: 0.4rem;
 
-  background-color: ${({ theme }) => theme.colors.gray_500};
+  color: ${({ theme }) => theme.colors.gray_500};
 `;
 
 export const ShowTypeText = styled.span`
+  margin-left: 0.4rem;
+
   ${({ theme }) => theme.fonts["caption2-semi"]};
   color: ${({ theme }) => theme.colors.gray_500};
 `;

--- a/src/pages/gig/components/showType/ShowType.tsx
+++ b/src/pages/gig/components/showType/ShowType.tsx
@@ -1,3 +1,4 @@
+import { IconSmallBand, IconSmallDance, IconSmallEtc, IconSmallMusical } from "@assets/svgs";
 import { SHOW_TYPE, ShowTypes } from "@pages/gig/constants";
 import * as S from "./ShowType.styled";
 
@@ -6,19 +7,46 @@ interface ShowTypeProps {
 }
 
 const ShowType = ({ type }: ShowTypeProps) => {
-  // TODO: 각 공연 타입에 따라 다른 뷰 리턴
-  if (type === SHOW_TYPE.BAND) {
-    return (
-      <S.ShowTypeWrapper>
-        {/* TODO: 아이콘 미정 */}
-        {/* {icon && <S.ShowTypeIcon>{icon}</S.ShowTypeIcon>} */}
-        <S.ShowTypeIcon />
-        <S.ShowTypeText>{SHOW_TYPE.BAND}</S.ShowTypeText>
-      </S.ShowTypeWrapper>
-    );
+  switch (type) {
+    case SHOW_TYPE.BAND:
+      return (
+        <S.ShowTypeWrapper>
+          <S.ShowTypeIcon>
+            <IconSmallBand />
+          </S.ShowTypeIcon>
+          <S.ShowTypeText>{SHOW_TYPE.BAND}</S.ShowTypeText>
+        </S.ShowTypeWrapper>
+      );
+    case SHOW_TYPE.DANCE:
+      return (
+        <S.ShowTypeWrapper>
+          <S.ShowTypeIcon>
+            <IconSmallDance />
+          </S.ShowTypeIcon>
+          <S.ShowTypeText>{SHOW_TYPE.DANCE}</S.ShowTypeText>
+        </S.ShowTypeWrapper>
+      );
+    case SHOW_TYPE.MUSICAL:
+      return (
+        <S.ShowTypeWrapper>
+          <S.ShowTypeIcon>
+            <IconSmallMusical />
+          </S.ShowTypeIcon>
+          <S.ShowTypeText>{SHOW_TYPE.MUSICAL}</S.ShowTypeText>
+        </S.ShowTypeWrapper>
+      );
+    case SHOW_TYPE.ETC:
+      return (
+        <S.ShowTypeWrapper>
+          <S.ShowTypeIcon>
+            <IconSmallEtc />
+          </S.ShowTypeIcon>
+          <S.ShowTypeText>{SHOW_TYPE.ETC}</S.ShowTypeText>
+        </S.ShowTypeWrapper>
+      );
+    default:
+      return null;
   }
-
-  return <></>;
 };
 
 export default ShowType;

--- a/src/pages/gig/constants/index.ts
+++ b/src/pages/gig/constants/index.ts
@@ -62,6 +62,8 @@ export const SHOW_TYPE = {
 
 export type ShowTypes = (typeof SHOW_TYPE)[keyof typeof SHOW_TYPE];
 
+export type SHOW_TYPE_KEY = keyof typeof SHOW_TYPE;
+
 export const TAB_TYPE = {
   PERFORMANCE: "performance",
   MAKER: "maker",


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #146 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 완료 페이지로 navigate (state 전달 포함)
- [x] genre에 따라 view 변경
- [x] 로그인 관련 바텀시트 추가
- [x] 카카오 로그인 연결
- [x] 출연진 없을 떄 보여줄 컴포넌트 추가
- [ ] 시간 형식 서버랑 논의하기
- [x] ShowType 각 공연 타입에 따라 다른 뷰 리턴
 헤더 뷰 및 네비게이션

## 📢 To Reviewers

- 카카오 로그인 테스트 필요합니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
