### PR TITLE
[Feat/#166] 로딩 컴포넌트 추가

### DIFF
--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { ButtonDelete24, IconProfile, IconArrowRight } from "@assets/svgs";
 
 export const HamburgerWrapper = styled.section`
-  position: absolute;
+  position: fixed;
   top: 0;
   right: -25.6rem;
   z-index: 10;

--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -4,7 +4,7 @@ import { ButtonDelete24, IconProfile, IconArrowRight } from "@assets/svgs";
 export const HamburgerWrapper = styled.section`
   position: absolute;
   top: 0;
-  right: 0;
+  right: -25.6rem;
   z-index: 10;
 
   display: flex;
@@ -14,15 +14,15 @@ export const HamburgerWrapper = styled.section`
   height: 100vh;
 
   background-color: ${({ theme }) => theme.colors.gray_900};
-  transform: translateX(100%);
   visibility: hidden;
 
   transition:
-    transform 0.5s ease,
+    right 0.5s ease,
     visibility 0.5s ease;
 
   &.open {
-    transform: translateX(0);
+    right: 0;
+
     visibility: visible;
   }
 `;

--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -17,11 +17,11 @@ export const HamburgerWrapper = styled.section`
   transform: translateX(100%);
   visibility: hidden;
 
-  transition: 0.5s ease;
+  transition:
+    transform 0.5s ease,
+    visibility 0.5s ease;
 
   &.open {
-    right: 0;
-
     transform: translateX(0);
     visibility: visible;
   }

--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -4,7 +4,7 @@ import { ButtonDelete24, IconProfile, IconArrowRight } from "@assets/svgs";
 export const HamburgerWrapper = styled.section`
   position: absolute;
   top: 0;
-  right: -25.6rem;
+  right: 0;
   z-index: 10;
 
   display: flex;
@@ -14,6 +14,7 @@ export const HamburgerWrapper = styled.section`
   height: 100vh;
 
   background-color: ${({ theme }) => theme.colors.gray_900};
+  transform: translateX(100%);
   visibility: hidden;
 
   transition: 0.5s ease;
@@ -21,6 +22,7 @@ export const HamburgerWrapper = styled.section`
   &.open {
     right: 0;
 
+    transform: translateX(0);
     visibility: visible;
   }
 `;

--- a/src/components/commons/hamburger/Hamburger.tsx
+++ b/src/components/commons/hamburger/Hamburger.tsx
@@ -43,6 +43,7 @@ const Hamburger = () => {
               <S.NavigateBtn
                 onClick={() => {
                   navigate("/gig-register");
+                  closeHamburger();
                 }}
               >
                 <S.NavigateBtnText>내가 등록한 공연</S.NavigateBtnText>
@@ -51,6 +52,7 @@ const Hamburger = () => {
               <S.NavigateBtn
                 onClick={() => {
                   navigate("/lookup");
+                  closeHamburger();
                 }}
               >
                 <S.NavigateBtnText>내가 예매한 공연</S.NavigateBtnText>

--- a/src/components/commons/hamburger/Hamburger.tsx
+++ b/src/components/commons/hamburger/Hamburger.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import useHamburger from "@hooks/useHamburger";
 import { hamburgerAtom } from "@stores/hamburger";

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -23,7 +23,7 @@ const Performance = ({ genre, performanceList }: PerformanceComponentProps) => {
   const navigate = useNavigate();
 
   const handleNavigate = () => {
-    navigate("/register");
+    navigate("/gig-register");
   };
 
   const filteredData =
@@ -44,9 +44,13 @@ const Performance = ({ genre, performanceList }: PerformanceComponentProps) => {
         ))}
       </S.PerformanceLayout>
       <Spacing marginBottom="1.5" />
-      <S.BannerWrapper onClick={handleNavigate}>
-        <S.Banner $image={BannerImg} />
-      </S.BannerWrapper>
+      {genre === "ALL" ? (
+        <S.BannerWrapper onClick={handleNavigate}>
+          <S.Banner $image={BannerImg} />
+        </S.BannerWrapper>
+      ) : (
+        <></>
+      )}
       <Spacing marginBottom="3.2" />
       <S.PerformanceLayout>
         {data2.map((item) => (


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #166

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

1. API 연결 이후 로딩 시 필요한 로딩 컴포넌트 생성

## 📢 To Reviewers

- 원하는 페이지 최상단에 `<Loading />` 컴포넌트 주면 됩니다~ API 연결 후에 로딩될 시간동안 이용하면 됩니다!

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/5241a00d-7b0f-4db3-b5dc-6308ded4f3f0)

실제로는 360도 돌아가는 영상입니다~
