### PR TITLE
[Fix/#169] 카카오 로그인 API 로직 수정 및 로그인 이후 페이지 연결

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,7 @@ const jsConfig = {
     "no-console": "warn",
     "no-extra-semi": "error",
     "no-unused-expressions": "error",
-    indent: ["error", 2, { SwitchCase: 1, ignoredNodes: ["PropertyDefinition"] }],
+    indent: "off", // prettier 충돌로 인해 off
     semi: ["warn", "always"],
     "no-undef": "error",
     "no-trailing-spaces": "warn",

--- a/src/components/commons/bank/InputAccountWrapper.tsx
+++ b/src/components/commons/bank/InputAccountWrapper.tsx
@@ -16,7 +16,9 @@ const InputWrapper = ({ children }: InputAccountWrapperProps) => {
       {childrenArray[0]}
       <Spacing marginBottom="1.2" />
       {childrenArray[1]}
-      <Spacing marginBottom="3.4" />
+      <Spacing marginBottom="1.2" />
+      {childrenArray[2]}
+      <Spacing marginBottom="1.6" />
     </S.InputAccountWrapper>
   );
 };

--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -1,12 +1,30 @@
-import styled from "styled-components";
-import { ButtonDelete24, IconProfile, IconArrowRight } from "@assets/svgs";
+import { ButtonDelete24, IconArrowRight, IconProfile } from "@assets/svgs";
+import styled, { css, keyframes } from "styled-components";
 
-export const HamburgerWrapper = styled.section`
+interface HamburgerWrapperProps {
+  $isOpen: boolean;
+  width: number;
+}
+
+const hamburgerAnimation = keyframes`
+  0% {
+    transform: translateX(100%);
+    opacity: 0;
+    visibility: hidden;
+  }
+  100%{
+    transform: translateX(0);
+    opacity: 1;
+    visibility: visible;
+
+  }
+`;
+
+export const HamburgerWrapper = styled.section<HamburgerWrapperProps>`
   position: absolute;
   top: 0;
-  right: -25.6rem;
+  left: ${({ width }) => `${width / 2 - 68}px`};
   z-index: 10;
-
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
@@ -14,24 +32,33 @@ export const HamburgerWrapper = styled.section`
   height: 100vh;
 
   background-color: ${({ theme }) => theme.colors.gray_900};
-  visibility: hidden;
+  transform: ${({ $isOpen }) => ($isOpen ? "translateX(0)" : "translateX(100%)")};
+  visibility: ${({ $isOpen }) => ($isOpen ? "visible" : "hidden")};
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
 
-  transition: 0.5s ease;
-
-  &.open {
-    right: 0;
-
-    visibility: visible;
-  }
+  animation: ${({ $isOpen }) =>
+      $isOpen &&
+      css`
+        ${hamburgerAnimation}
+      `}
+    0.2s ease-in-out;
 `;
 
-export const Overlay = styled.div`
+export const Overlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
   z-index: 5;
   width: 100%;
   height: 100%;
+
+  background-color: rgb(0 0 0 / 70%);
+  visibility: ${({ $isOpen }) => ($isOpen ? "visible" : "hidden")};
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+
+  transition:
+    opacity 200ms ease-in-out,
+    visibility 200ms ease-in-out;
 `;
 
 export const CloseBtn = styled.section`

--- a/src/components/commons/hamburger/Hamburger.tsx
+++ b/src/components/commons/hamburger/Hamburger.tsx
@@ -1,15 +1,20 @@
 import useHamburger from "@hooks/useHamburger";
 import { hamburgerAtom } from "@stores/hamburger";
-import { requestKakaoLogin } from "@utils/kakaoLogin";
-import { useAtomValue } from "jotai";
+
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as S from "./Hamburger.styled";
+
+import { useAtom, useAtomValue } from "jotai";
+
+import { navigateAtom } from "@stores/navigate";
+import { requestKakaoLogin } from "@utils/kakaoLogin";
 
 const Hamburger = () => {
   const navigate = useNavigate();
 
   const { isOpen } = useAtomValue(hamburgerAtom);
+  const [, setNavigateUrl] = useAtom(navigateAtom);
 
   const [isLogin, setIsLogin] = useState(true);
 
@@ -45,6 +50,11 @@ const Hamburger = () => {
       document.body.style.overflow = "auto";
     };
   }, [isOpen]);
+
+  const handleKakaoLogin = (url: string) => {
+    setNavigateUrl(url);
+    requestKakaoLogin();
+  };
 
   return (
     <>
@@ -88,7 +98,7 @@ const Hamburger = () => {
             <>
               <S.ProfileContainer>
                 <S.ProfileIcon />
-                <S.LoginBtn onClick={requestKakaoLogin}>로그인 하기</S.LoginBtn>
+                <S.LoginBtn onClick={() => handleKakaoLogin("/main")}>로그인 하기</S.LoginBtn>
               </S.ProfileContainer>
               <S.NavigateBtn
                 onClick={() => {

--- a/src/components/commons/hamburger/Hamburger.tsx
+++ b/src/components/commons/hamburger/Hamburger.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
 import useHamburger from "@hooks/useHamburger";
 import { hamburgerAtom } from "@stores/hamburger";
-import { useAtomValue } from "jotai";
-import * as S from "./Hamburger.styled";
 import { requestKakaoLogin } from "@utils/kakaoLogin";
+import { useAtomValue } from "jotai";
+import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import * as S from "./Hamburger.styled";
 
 const Hamburger = () => {
   const navigate = useNavigate();
@@ -21,60 +21,87 @@ const Hamburger = () => {
     e.stopPropagation();
   };
 
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen]);
+
   return (
     <>
-      {isOpen && <S.Overlay onClick={handlerOutside} />}
-      <S.HamburgerWrapper
-        ref={outside}
-        className={isOpen ? "open" : ""}
-        onClick={(e) => e.preventDefault()}
-      >
-        <S.CloseBtn onClick={closeHamburger}>
-          <S.CloseIcon />
-        </S.CloseBtn>
-        {isLogin ? (
-          <>
-            <S.ProfileContainer>
-              <S.ProfileIcon />
-              {/* 이 부분 API 연결하면 사용자 이름으로 변경 */}
-              <S.UserName>프로필 이름</S.UserName>
-            </S.ProfileContainer>
-            <S.NavigateBtnWrapper>
+      <S.Overlay $isOpen={isOpen} onClick={handlerOutside}>
+        <S.HamburgerWrapper
+          $isOpen={isOpen}
+          ref={outside}
+          onClick={(e) => e.stopPropagation()}
+          width={width}
+        >
+          <S.CloseBtn onClick={closeHamburger}>
+            <S.CloseIcon />
+          </S.CloseBtn>
+          {isLogin ? (
+            <>
+              <S.ProfileContainer>
+                <S.ProfileIcon />
+                {/* 이 부분 API 연결하면 사용자 이름으로 변경 */}
+                <S.UserName>프로필 이름</S.UserName>
+              </S.ProfileContainer>
+              <S.NavigateBtnWrapper>
+                <S.NavigateBtn
+                  onClick={() => {
+                    navigate("/gig-register");
+                  }}
+                >
+                  <S.NavigateBtnText>내가 등록한 공연</S.NavigateBtnText>
+                  <S.ArrowRightIcon />
+                </S.NavigateBtn>
+                <S.NavigateBtn
+                  onClick={() => {
+                    navigate("/lookup");
+                  }}
+                >
+                  <S.NavigateBtnText>내가 예매한 공연</S.NavigateBtnText>
+                  <S.ArrowRightIcon />
+                </S.NavigateBtn>
+              </S.NavigateBtnWrapper>
+            </>
+          ) : (
+            <>
+              <S.ProfileContainer>
+                <S.ProfileIcon />
+                <S.LoginBtn onClick={requestKakaoLogin}>로그인 하기</S.LoginBtn>
+              </S.ProfileContainer>
               <S.NavigateBtn
                 onClick={() => {
-                  navigate("/gig-register");
+                  navigate("/nonmb-lookup");
                 }}
               >
-                <S.NavigateBtnText>내가 등록한 공연</S.NavigateBtnText>
+                <S.NavigateBtnText>비회원 예매 조회</S.NavigateBtnText>
                 <S.ArrowRightIcon />
               </S.NavigateBtn>
-              <S.NavigateBtn
-                onClick={() => {
-                  navigate("/lookup");
-                }}
-              >
-                <S.NavigateBtnText>내가 예매한 공연</S.NavigateBtnText>
-                <S.ArrowRightIcon />
-              </S.NavigateBtn>
-            </S.NavigateBtnWrapper>
-          </>
-        ) : (
-          <>
-            <S.ProfileContainer>
-              <S.ProfileIcon />
-              <S.LoginBtn onClick={requestKakaoLogin}>로그인 하기</S.LoginBtn>
-            </S.ProfileContainer>
-            <S.NavigateBtn
-              onClick={() => {
-                navigate("/nonmb-lookup");
-              }}
-            >
-              <S.NavigateBtnText>비회원 예매 조회</S.NavigateBtnText>
-              <S.ArrowRightIcon />
-            </S.NavigateBtn>
-          </>
-        )}
-      </S.HamburgerWrapper>
+            </>
+          )}
+        </S.HamburgerWrapper>
+      </S.Overlay>
     </>
   );
 };

--- a/src/components/commons/input/textField/TextField.tsx
+++ b/src/components/commons/input/textField/TextField.tsx
@@ -10,7 +10,6 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   unit?: "time" | "ticket" | "amount"; // 단위 : "분", "매", "원"
   filter?: (value: string) => string;
   cap?: false | true;
-  onToggleClick?: () => void;
 }
 
 const TextField = ({
@@ -24,7 +23,6 @@ const TextField = ({
   unit,
   filter,
   cap,
-  onToggleClick,
   ...rest
 }: TextFieldProps) => {
   const label = unit === "time" ? "분" : unit === "ticket" ? "매" : "원";

--- a/src/pages/KakaoLoginTest.tsx
+++ b/src/pages/KakaoLoginTest.tsx
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { useAtom } from "jotai";
+import { navigateAtom } from "@stores/navigate";
 
 import Button from "@components/commons/button/Button";
 
@@ -7,9 +9,16 @@ import { requestKakaoLogin } from "@utils/kakaoLogin";
 // 실제 사용할 때는 원하는 페이지에 button onClick에 requestKakaoLogin만 주면 됨
 
 const KakaoLoginTest = () => {
+  const [, setNavigateUrl] = useAtom(navigateAtom);
+
+  const handleKakaoLogin = (url: string) => {
+    setNavigateUrl(url);
+    requestKakaoLogin();
+  };
+
   return (
     <Test>
-      <Button onClick={requestKakaoLogin}>카카오 로그인 테스트~~</Button>
+      <Button onClick={() => handleKakaoLogin("/gig-register")}>카카오 로그인 테스트~~</Button>
     </Test>
   );
 };

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -5,6 +5,8 @@ import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader } from "@hooks/useHeader";
 import { requestKakaoLogin } from "@utils/kakaoLogin";
 import { useEffect, useState } from "react";
+import { useAtom } from "jotai";
+import { navigateAtom } from "@stores/navigate";
 import { useNavigate, useParams } from "react-router-dom";
 import Content from "./components/content/Content";
 import ShowInfo from "./components/showInfo/ShowInfo";
@@ -13,6 +15,7 @@ import * as S from "./Gig.styled";
 
 const Gig = () => {
   const navigate = useNavigate();
+  const [, setNavigateUrl] = useAtom(navigateAtom);
   const { setHeader } = useHeader();
   const isLoggedIn = false;
 
@@ -40,6 +43,11 @@ const Gig = () => {
     }
 
     setIsSheetOpen(true);
+  };
+
+  const handleKakaoLogin = (url: string) => {
+    setNavigateUrl(url);
+    requestKakaoLogin();
   };
 
   const handleSheetClose = () => {
@@ -82,7 +90,7 @@ const Gig = () => {
               variant="primary"
               size="xlarge"
               style={{ backgroundColor: "#FEE500", color: "#0F0F0F" }}
-              onClick={requestKakaoLogin}
+              onClick={() => handleKakaoLogin(`/book/${performanceId}`)}
             >
               카카오 로그인
             </Button>

--- a/src/pages/kakaoLogin/KakaoLogin.tsx
+++ b/src/pages/kakaoLogin/KakaoLogin.tsx
@@ -1,33 +1,32 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { getToken } from "@apis/kakoLogin/postKakaoToken";
-import { getData } from "@apis/kakoLogin/getKakaoData";
+import { navigateAtom } from "@stores/navigate";
+import { useAtom } from "jotai";
 
 const KakaoLogin = () => {
   const navigate = useNavigate();
+  const [navigateUrl] = useAtom(navigateAtom);
+
+  const [readyLogin, setReadyLogin] = useState(false);
+
+  // 로그인 완료되면 상태 확인
+  useEffect(() => {
+    if (readyLogin) {
+      navigate(navigateUrl);
+    }
+  }, [readyLogin]);
 
   const code = new URL(window.location.href).searchParams.get("code");
 
   useEffect(() => {
     const fetchData = async () => {
       if (code) {
-        // 전에 있던 페이지에 따라 어떤 페이지로 이동할 건지 분기처리 필요
-        // 분기 처리 안 되면 이전 페이지로 이동
-        navigate("/kakao-login");
-
         try {
-          const token = await getToken(code);
-          const userData = await getData(token);
+          // 인가 코드 서버에 전송
+          console.log(code);
 
-          // 이 부분 이메일 + 닉네임 + 인가코드까지 서버에 POST
-          // 현재는 임시로 console 찍어뒀는데, API POST 붙이기
-
-          const nickname = userData.properties.nickname;
-          const email = userData.kakao_account.email;
-
-          console.log(userData);
-          console.log(`Nickname: ${nickname}, Email: ${email}`);
+          setReadyLogin(true);
         } catch (error) {
           console.error(error);
         }
@@ -37,7 +36,7 @@ const KakaoLogin = () => {
     fetchData();
   }, [code, navigate]);
 
-  return <div>로그인 과정 페이지~ </div>;
+  return <div></div>;
 };
 
 export default KakaoLogin;

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -9,6 +9,8 @@ import Performance from "./components/performance/Performance";
 
 import Floating from "./components/floating/Floating";
 import { dummyData } from "./constants/dummyData";
+import { useAtom } from "jotai";
+import { navigateAtom } from "@stores/navigate";
 
 const Main = () => {
   const [genre, setGenre] = useState("ALL");
@@ -16,6 +18,10 @@ const Main = () => {
   const handleGenre = (value: string) => {
     setGenre(value);
   };
+
+  const [navigateUrl, setNavigateUrl] = useAtom(navigateAtom);
+
+  console.log("main", navigateUrl);
 
   return (
     <S.MainWrapper>

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import * as S from "./Main.styled";
 
-import MainNavigation from "./components/mainNavigation/MainNavigation";
 import Carousel from "./components/carousel/Carousel";
 import Chips from "./components/chips/Chips";
-import Floating from "./components/floating/Floating";
-import Performance from "./components/performance/Performance";
 import Footer from "./components/footer/Footer";
+import MainNavigation from "./components/mainNavigation/MainNavigation";
+import Performance from "./components/performance/Performance";
 
+import Floating from "./components/floating/Floating";
 import { dummyData } from "./constants/dummyData";
 
 const Main = () => {

--- a/src/pages/main/components/mainNavigation/MainNavigation.styled.ts
+++ b/src/pages/main/components/mainNavigation/MainNavigation.styled.ts
@@ -1,5 +1,5 @@
+import { IcHamburgar, IconFooterLogo } from "@assets/svgs";
 import styled from "styled-components";
-import { IconFooterLogo, IcHamburgar } from "@assets/svgs";
 
 export const MainNavigationWrapper = styled.section`
   position: absolute;

--- a/src/pages/main/components/mainNavigation/MainNavigation.tsx
+++ b/src/pages/main/components/mainNavigation/MainNavigation.tsx
@@ -1,8 +1,8 @@
-import * as S from "./MainNavigation.styled";
 import { useNavigate } from "react-router-dom";
+import * as S from "./MainNavigation.styled";
 
-import Hamburger from "../../../../components/commons/hamburger/Hamburger";
 import useHamburger from "@hooks/useHamburger";
+import Hamburger from "../../../../components/commons/hamburger/Hamburger";
 
 const MainNavigation = () => {
   const navigate = useNavigate();

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -23,7 +23,7 @@ const Performance = ({ genre, performanceList }: PerformanceComponentProps) => {
   const navigate = useNavigate();
 
   const handleNavigate = () => {
-    navigate("/register");
+    navigate("/gig-register");
   };
 
   const filteredData =
@@ -44,9 +44,13 @@ const Performance = ({ genre, performanceList }: PerformanceComponentProps) => {
         ))}
       </S.PerformanceLayout>
       <Spacing marginBottom="1.5" />
-      <S.BannerWrapper onClick={handleNavigate}>
-        <S.Banner $image={BannerImg} />
-      </S.BannerWrapper>
+      {genre === "ALL" ? (
+        <S.BannerWrapper onClick={handleNavigate}>
+          <S.Banner $image={BannerImg} />
+        </S.BannerWrapper>
+      ) : (
+        <></>
+      )}
       <Spacing marginBottom="3.2" />
       <S.PerformanceLayout>
         {data2.map((item) => (

--- a/src/pages/register/Register.styled.ts
+++ b/src/pages/register/Register.styled.ts
@@ -84,8 +84,8 @@ export const InputTitle = styled.h1`
   ${({ theme }) => theme.fonts.heading4};
 `;
 
-export const InputDescription = styled.p<{ warning?: boolean }>`
-  color: ${({ theme, warning }) => (warning ? theme.colors.red : theme.colors.gray_300)};
+export const InputDescription = styled.p<{ $warning?: boolean }>`
+  color: ${({ theme, $warning }) => ($warning ? theme.colors.red : theme.colors.gray_300)};
   ${({ theme }) => theme.fonts["body2-long"]};
 `;
 
@@ -179,9 +179,10 @@ export const GenreItem = styled.article<{ selected: boolean }>`
 `;
 
 export const StyledIcon = (IconComponent: ComponentType) => styled(IconComponent)<{
-  selected: boolean;
+  $selected: boolean;
 }>`
-  fill: ${({ theme, selected }) => (selected ? theme.colors.main_pink_400 : theme.colors.gray_500)};
+  fill: ${({ theme, $selected }) =>
+    $selected ? theme.colors.main_pink_400 : theme.colors.gray_500};
 `;
 
 export const TimePickerWrapper = styled.section`

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -52,6 +52,7 @@ const Register = () => {
     performanceAttentionNote: "", // 유의사항
     bankName: "", // 은행명
     accountNumber: "", // 계좌번호
+    accountHolder: "", // 예금주
     posterImage: "", // 포스터 이미지 URL
     performanceTeamName: "", // 공연 팀명
     performanceVenue: "", // 공연 장소
@@ -90,6 +91,7 @@ const Register = () => {
     performanceDescription,
     performanceAttentionNote,
     accountNumber,
+    accountHolder,
     posterImage,
     performanceTeamName,
     performanceVenue,
@@ -286,25 +288,6 @@ const Register = () => {
             />
           </InputRegisterBox>
           <S.Divider />
-          <InputRegisterBox
-            title="티켓 가격"
-            description="*티켓 가격은 수정불가합니다."
-            isFree={isFree}
-            onFreeClick={() => onFreeClick(setIsFree)}
-          >
-            <TextField
-              type="input"
-              name="ticketPrice"
-              value={ticketPrice !== null ? priceFilter(ticketPrice.toString()) : ""}
-              onChange={(e) => {
-                handleChange(e as ChangeEvent<HTMLInputElement>, setGigInfo);
-              }}
-              placeholder="가격을 입력해주세요."
-              disabled={isFree}
-              unit="amount"
-            />
-          </InputRegisterBox>
-          <S.Divider />
           <InputRegisterBox title="회차별 티켓 판매수">
             <TextField
               type="input"
@@ -331,6 +314,25 @@ const Register = () => {
             />
           </InputRegisterBox>
           <S.Divider />
+          <InputRegisterBox
+            title="티켓 가격"
+            description="*티켓 가격은 수정불가합니다."
+            isFree={isFree}
+            onFreeClick={() => onFreeClick(setIsFree)}
+          >
+            <TextField
+              type="input"
+              name="ticketPrice"
+              value={ticketPrice !== null ? priceFilter(ticketPrice.toString()) : ""}
+              onChange={(e) => {
+                handleChange(e as ChangeEvent<HTMLInputElement>, setGigInfo);
+              }}
+              placeholder="가격을 입력해주세요."
+              disabled={isFree}
+              unit="amount"
+            />
+          </InputRegisterBox>
+          <S.Divider />
           {!isFree && (
             <>
               <InputAccountWrapper>
@@ -343,6 +345,12 @@ const Register = () => {
                   onChange={(e) => handleChange(e, setGigInfo)}
                   filter={numericFilter}
                   placeholder="입금 받으실 계좌번호를 (-)제외 숫자만 입력해주세요."
+                />
+                <TextField
+                  name="accountHolder"
+                  value={accountHolder}
+                  onChange={(e) => handleChange(e, setGigInfo)}
+                  placeholder="예금주명을 입력해주세요."
                 />
               </InputAccountWrapper>
               <S.Divider />

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -38,6 +38,7 @@ import ShowInfo from "@pages/gig/components/showInfo/ShowInfo";
 import useModal from "@hooks/useModal";
 import { useNavigate } from "react-router-dom";
 import Content from "@pages/gig/components/content/Content";
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 
 const Register = () => {
   const [registerStep, setRegisterStep] = useState(1); // 등록 step 나누기
@@ -45,7 +46,7 @@ const Register = () => {
   // gigInfo 초기화
   const [gigInfo, setGigInfo] = useState<GigInfo>({
     performanceTitle: "", // 공연명
-    genre: "", // 공연 장르
+    genre: "" as SHOW_TYPE_KEY, // 공연 장르
     runningTime: null, // 러닝 타임
     performanceDescription: "", // 공연 소개
     performanceAttentionNote: "", // 유의사항
@@ -61,7 +62,7 @@ const Register = () => {
     scheduleList: [
       {
         performanceDate: null, // 공연 일시
-        totalTicketCount: "", // 총 티켓 수
+        totalTicketCount: null, // 총 티켓 수
         scheduleNumber: "FIRST", // 회차 번호
       },
     ],
@@ -138,7 +139,7 @@ const Register = () => {
 
   // 티켓 가격을 0으로 작성하면 자동으로 무료 공연 체크
   useEffect(() => {
-    if (ticketPrice == 0) {
+    if (ticketPrice === 0) {
       setIsFree(true);
     }
   }, [ticketPrice]);
@@ -161,7 +162,7 @@ const Register = () => {
     if (registerStep === 1) {
       openConfirm({
         title: "정말 나가시겠습니까?",
-        subTitle: "지금 나가실 경우 작성하신 내용이 저장되지 않습니다.",
+        subTitle: "지금 나가실 경우 작성하신 내용이 저장되지\n 않습니다.",
         okText: "작성할게요",
         okCallback: () => {
           setRegisterStep(1);
@@ -241,8 +242,10 @@ const Register = () => {
             <TextField
               type="input"
               name="runningTime"
-              value={runningTime ?? ""}
-              onChange={(e) => handleChange(e, setGigInfo)}
+              value={runningTime !== null ? runningTime.toString() : ""}
+              onChange={(e) => {
+                handleChange(e as ChangeEvent<HTMLInputElement>, setGigInfo);
+              }}
               filter={numericFilter}
               unit="time"
               placeholder="공연의 러닝 타임을 분 단위로 입력해주세요."
@@ -292,10 +295,11 @@ const Register = () => {
             <TextField
               type="input"
               name="ticketPrice"
-              value={ticketPrice ?? ""}
-              onChange={(e) => handleChange(e, setGigInfo)}
+              value={ticketPrice !== null ? priceFilter(ticketPrice.toString()) : ""}
+              onChange={(e) => {
+                handleChange(e as ChangeEvent<HTMLInputElement>, setGigInfo);
+              }}
               placeholder="가격을 입력해주세요."
-              filter={priceFilter}
               disabled={isFree}
               unit="amount"
             />
@@ -305,7 +309,11 @@ const Register = () => {
             <TextField
               type="input"
               name="totalTicketCount"
-              value={scheduleList[0].totalTicketCount}
+              value={
+                scheduleList[0].totalTicketCount !== null
+                  ? scheduleList[0].totalTicketCount.toString()
+                  : ""
+              }
               onChange={(e) => handleTotalTicketCountChange(e, setGigInfo)}
               placeholder="판매할 티켓의 매 수를 입력해주세요."
               filter={numericFilter}
@@ -399,6 +407,7 @@ const Register = () => {
         <S.PreviewBanner>예매자에게 보여질 화면 예시입니다. 확인해주세요.</S.PreviewBanner>
         <ShowInfo
           posterImage={posterImage}
+          genre={genre}
           title={performanceTitle}
           price={ticketPrice}
           venue={performanceVenue}

--- a/src/pages/register/components/GenreSelect.tsx
+++ b/src/pages/register/components/GenreSelect.tsx
@@ -1,17 +1,19 @@
 import Spacing from "@components/commons/spacing/Spacing";
 import * as S from "../Register.styled";
 import { ComponentType } from "react";
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 
 interface Genre {
   id: number;
-  genre: string;
-  genreIcon: ComponentType;
+  genre: SHOW_TYPE_KEY;
+  genre_kr: string;
+  genreIcon: ComponentType<{ $selected: boolean }>;
 }
 interface GenreSelectProps {
   title: string;
   genres: Genre[];
-  selectedGenre: string;
-  onGenreSelect: (genre: string) => void;
+  selectedGenre: SHOW_TYPE_KEY;
+  onGenreSelect: (genre: SHOW_TYPE_KEY) => void;
   marginBottom?: number;
 }
 
@@ -28,15 +30,14 @@ const GenreSelect = ({
       <Spacing marginBottom={"1.4"} />
       <S.GenreContainer>
         {genres.map((genre) => {
-          const GenreIcon = S.StyledIcon(genre.genreIcon);
           return (
             <S.GenreItem
               key={genre.id}
               onClick={() => onGenreSelect(genre.genre)}
               selected={selectedGenre === genre.genre}
             >
-              <GenreIcon selected={selectedGenre === genre.genre} />
-              {genre.genre}
+              <genre.genreIcon $selected={selectedGenre === genre.genre} />
+              {genre.genre_kr}
             </S.GenreItem>
           );
         })}

--- a/src/pages/register/components/InputRegisterBox.tsx
+++ b/src/pages/register/components/InputRegisterBox.tsx
@@ -35,7 +35,7 @@ const InputRegisterBox = ({
           </S.CheckBox>
         )}
       </S.InputTitle>
-      <S.InputDescription warning={true}>{description}</S.InputDescription>
+      <S.InputDescription $warning={true}>{description}</S.InputDescription>
       <Spacing marginBottom={"1.4"} />
       {children}
     </S.InputRegisterBox>

--- a/src/pages/register/components/PosterThumbnail.tsx
+++ b/src/pages/register/components/PosterThumbnail.tsx
@@ -11,6 +11,7 @@ interface PosterThumbnailProps {
 const PosterThumbnail = ({ value, onImageUpload }: PosterThumbnailProps) => {
   const [postImg, setPostImg] = useState<File | null>(null);
   const [previewImg, setPreviewImg] = useState<string | null>(value || null);
+  const [inputKey, setInputKey] = useState<number>(Date.now());
 
   useEffect(() => {
     setPreviewImg(value || null);
@@ -19,11 +20,10 @@ const PosterThumbnail = ({ value, onImageUpload }: PosterThumbnailProps) => {
   const uploadFile = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      setPostImg(file);
-
       const fileReader = new FileReader();
       fileReader.onload = function (event) {
         const imageUrl = event.target?.result as string;
+        setPostImg(file);
         setPreviewImg(imageUrl);
         onImageUpload(imageUrl);
       };
@@ -33,7 +33,9 @@ const PosterThumbnail = ({ value, onImageUpload }: PosterThumbnailProps) => {
   };
 
   const removeImage = () => {
+    setPostImg(null);
     setPreviewImg(null);
+    setInputKey(Date.now());
     onImageUpload("");
   };
 
@@ -43,7 +45,7 @@ const PosterThumbnail = ({ value, onImageUpload }: PosterThumbnailProps) => {
       <S.InputDescription>한 장만 등록 가능합니다.</S.InputDescription>
       <Spacing marginBottom="1.4" />
       <S.FileInputWrapper>
-        <S.HiddenFileInput type="file" id="file" onChange={uploadFile} />
+        <S.HiddenFileInput key={inputKey} type="file" id="file" onChange={uploadFile} />
         <S.CustomFileInput htmlFor="file">
           <IconCamera width={"3.2rem"} />
         </S.CustomFileInput>

--- a/src/pages/register/constants/genreList.ts
+++ b/src/pages/register/constants/genreList.ts
@@ -1,8 +1,20 @@
 import { IconLargeMusical, IconLargeBand, IconLargeDance, IconLargeEtc } from "@assets/svgs";
+import { StyledIcon } from "../Register.styled";
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 
 export const GENRE_LIST = [
-  { id: 1, genre: "연극/뮤지컬", genreIcon: IconLargeMusical },
-  { id: 2, genre: "밴드", genreIcon: IconLargeBand },
-  { id: 3, genre: "댄스", genreIcon: IconLargeDance },
-  { id: 4, genre: "기타", genreIcon: IconLargeEtc },
+  {
+    id: 1,
+    genre: "PLAY" as SHOW_TYPE_KEY,
+    genre_kr: "연극/뮤지컬",
+    genreIcon: StyledIcon(IconLargeMusical),
+  },
+  { id: 2, genre: "BAND" as SHOW_TYPE_KEY, genre_kr: "밴드", genreIcon: StyledIcon(IconLargeBand) },
+  {
+    id: 3,
+    genre: "DANCE" as SHOW_TYPE_KEY,
+    genre_kr: "댄스",
+    genreIcon: StyledIcon(IconLargeDance),
+  },
+  { id: 4, genre: "ETC" as SHOW_TYPE_KEY, genre_kr: "기타", genreIcon: StyledIcon(IconLargeEtc) },
 ];

--- a/src/pages/register/typings/gigInfo.ts
+++ b/src/pages/register/typings/gigInfo.ts
@@ -27,6 +27,7 @@ export interface GigInfo {
   performanceAttentionNote: string;
   bankName: string;
   accountNumber: string;
+  accountHolder: string;
   posterImage: string;
   performanceTeamName: string;
   performanceVenue: string;

--- a/src/pages/register/typings/gigInfo.ts
+++ b/src/pages/register/typings/gigInfo.ts
@@ -1,8 +1,9 @@
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 import { Dayjs } from "dayjs";
 
 export interface Schedule {
   performanceDate: Dayjs | null;
-  totalTicketCount: string;
+  totalTicketCount: number | null;
   scheduleNumber: string;
 }
 
@@ -20,7 +21,7 @@ export interface Staff {
 
 export interface GigInfo {
   performanceTitle: string;
-  genre: string;
+  genre: SHOW_TYPE_KEY;
   runningTime: number | null;
   performanceDescription: string;
   performanceAttentionNote: string;

--- a/src/pages/register/utils/handleEvent.ts
+++ b/src/pages/register/utils/handleEvent.ts
@@ -1,6 +1,7 @@
 import { Dayjs } from "dayjs";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { GigInfo } from "../typings/gigInfo";
+import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 
 // Image 핸들링
 export const handleImageUpload = (
@@ -15,7 +16,7 @@ export const handleImageUpload = (
 
 // Genre 핸들링
 export const handleGenreSelect = (
-  selectedGenre: string,
+  selectedGenre: SHOW_TYPE_KEY,
   setGigInfo: Dispatch<SetStateAction<GigInfo>>
 ) => {
   setGigInfo((prev) => ({
@@ -30,10 +31,20 @@ export const handleChange = (
   setGigInfo: Dispatch<SetStateAction<GigInfo>>
 ) => {
   const { name, value } = e.target;
-  setGigInfo((prev) => ({
-    ...prev,
-    [name]: value,
-  }));
+
+  // 숫자 타입 처리 추가
+  if (name === "ticketPrice" || name === "runningTime" || name === "totalTicketCount") {
+    const numericValue = parseInt(value.replace(/,/g, ""), 10);
+    setGigInfo((prev: GigInfo) => ({
+      ...prev,
+      [name]: isNaN(numericValue) ? null : numericValue,
+    }));
+  } else {
+    setGigInfo((prev: GigInfo) => ({
+      ...prev,
+      [name]: value,
+    }));
+  }
 };
 
 // Stepper 핸들링
@@ -55,7 +66,7 @@ export const onPlusClick = (setGigInfo: Dispatch<SetStateAction<GigInfo>>) => {
       ...prev.scheduleList,
       {
         performanceDate: null, // 공연 일시
-        totalTicketCount: "", // 총 티켓 수
+        totalTicketCount: null, // 총 티켓 수
         scheduleNumber: getScheduleNumber(prev.scheduleList.length), // 회차 번호
       },
     ];
@@ -91,11 +102,12 @@ export const handleTotalTicketCountChange = (
   setGigInfo: Dispatch<SetStateAction<GigInfo>>
 ) => {
   const { value } = e.target;
+  const numericValue = parseInt(value, 10);
   setGigInfo((prev) => ({
     ...prev,
     scheduleList: prev.scheduleList.map((schedule) => ({
       ...schedule,
-      totalTicketCount: value,
+      totalTicketCount: isNaN(numericValue) ? null : numericValue,
     })),
   }));
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter([
     element: <Layout />,
     children: [
       { path: "a", element: <Apage /> },
-      { path: "/NonMb-Lookup", element: <NonMbLookup /> },
+      { path: "NonMb-Lookup", element: <NonMbLookup /> },
       { path: "lookup", element: <Lookup /> },
       { path: "book/complete", element: <Complete /> },
       { path: "book/:performanceId", element: <Book /> },

--- a/src/stores/navigate.ts
+++ b/src/stores/navigate.ts
@@ -1,0 +1,3 @@
+import { atomWithStorage } from "jotai/utils";
+
+export const navigateAtom = atomWithStorage<string>("navigateUrl", "/main");

--- a/src/utils/useInputFilter.ts
+++ b/src/utils/useInputFilter.ts
@@ -1,5 +1,5 @@
 export const numericFilter = (value: string) => {
-  return value.replace(/\D/g, "");
+  return value.replace(/[^0-9]/g, "");
 };
 
 export const phoneNumberFilter = (value: string) => {

--- a/vite.config.ts.timestamp-1721073999219-c632ba1a33cfb.mjs
+++ b/vite.config.ts.timestamp-1721073999219-c632ba1a33cfb.mjs
@@ -1,0 +1,27 @@
+// vite.config.ts
+import react from "file:///E:/BEAT/BEAT-Client/node_modules/@vitejs/plugin-react-swc/index.mjs";
+import { defineConfig } from "file:///E:/BEAT/BEAT-Client/node_modules/vite/dist/node/index.js";
+import svgr from "file:///E:/BEAT/BEAT-Client/node_modules/vite-plugin-svgr/dist/index.js";
+import tsconfigPaths from "file:///E:/BEAT/BEAT-Client/node_modules/vite-tsconfig-paths/dist/index.mjs";
+var vite_config_default = defineConfig({
+  plugins: [
+    react(),
+    svgr({
+      svgrOptions: {
+        icon: true,
+        memo: true
+      }
+    }),
+    tsconfigPaths()
+  ],
+  resolve: {
+    extensions: [".js", ".jsx", ".ts", ".tsx"]
+  },
+  optimizeDeps: {
+    include: ["react-lottie-player"]
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCJFOlxcXFxCRUFUXFxcXEJFQVQtQ2xpZW50XCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ZpbGVuYW1lID0gXCJFOlxcXFxCRUFUXFxcXEJFQVQtQ2xpZW50XFxcXHZpdGUuY29uZmlnLnRzXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ltcG9ydF9tZXRhX3VybCA9IFwiZmlsZTovLy9FOi9CRUFUL0JFQVQtQ2xpZW50L3ZpdGUuY29uZmlnLnRzXCI7aW1wb3J0IHJlYWN0IGZyb20gXCJAdml0ZWpzL3BsdWdpbi1yZWFjdC1zd2NcIjtcclxuaW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSBcInZpdGVcIjtcclxuaW1wb3J0IHN2Z3IgZnJvbSBcInZpdGUtcGx1Z2luLXN2Z3JcIjtcclxuaW1wb3J0IHRzY29uZmlnUGF0aHMgZnJvbSBcInZpdGUtdHNjb25maWctcGF0aHNcIjtcclxuXHJcbi8vIGh0dHBzOi8vdml0ZWpzLmRldi9jb25maWcvXHJcbmV4cG9ydCBkZWZhdWx0IGRlZmluZUNvbmZpZyh7XHJcbiAgcGx1Z2luczogW1xyXG4gICAgcmVhY3QoKSxcclxuICAgIHN2Z3Ioe1xyXG4gICAgICBzdmdyT3B0aW9uczoge1xyXG4gICAgICAgIGljb246IHRydWUsXHJcbiAgICAgICAgbWVtbzogdHJ1ZSxcclxuICAgICAgfSxcclxuICAgIH0pLFxyXG4gICAgdHNjb25maWdQYXRocygpLFxyXG4gIF0sXHJcbiAgcmVzb2x2ZToge1xyXG4gICAgZXh0ZW5zaW9uczogW1wiLmpzXCIsIFwiLmpzeFwiLCBcIi50c1wiLCBcIi50c3hcIl0sXHJcbiAgfSxcclxuICBvcHRpbWl6ZURlcHM6IHtcclxuICAgIGluY2x1ZGU6IFtcInJlYWN0LWxvdHRpZS1wbGF5ZXJcIl0sXHJcbiAgfSxcclxufSk7XHJcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFBaVAsT0FBTyxXQUFXO0FBQ25RLFNBQVMsb0JBQW9CO0FBQzdCLE9BQU8sVUFBVTtBQUNqQixPQUFPLG1CQUFtQjtBQUcxQixJQUFPLHNCQUFRLGFBQWE7QUFBQSxFQUMxQixTQUFTO0FBQUEsSUFDUCxNQUFNO0FBQUEsSUFDTixLQUFLO0FBQUEsTUFDSCxhQUFhO0FBQUEsUUFDWCxNQUFNO0FBQUEsUUFDTixNQUFNO0FBQUEsTUFDUjtBQUFBLElBQ0YsQ0FBQztBQUFBLElBQ0QsY0FBYztBQUFBLEVBQ2hCO0FBQUEsRUFDQSxTQUFTO0FBQUEsSUFDUCxZQUFZLENBQUMsT0FBTyxRQUFRLE9BQU8sTUFBTTtBQUFBLEVBQzNDO0FBQUEsRUFDQSxjQUFjO0FBQUEsSUFDWixTQUFTLENBQUMscUJBQXFCO0FBQUEsRUFDakM7QUFDRixDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #169 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

1. 카카오 로그인 바뀐 API 명세서 맞춰 수정
2. 로그인 이후 이동할 페이지 선택할 수 있도록 수정

## 📢 To Reviewers

```
const [, setNavigateUrl] = useAtom(navigateAtom);

  const handleKakaoLogin = (url: string) => {
    setNavigateUrl(url);
    requestKakaoLogin();
  };
```

로 위에 선언해 주고, 


```
onClick={() => handleKakaoLogin("/로그인 이후 이동 원하는 페이지 주소")}
```
해주면 로그인 다음 로직을 선택할 수 있습니다!
