### PR TITLE
[Feat/#192] 예매 관련 공연 정보 조회 API, 티켓 예매 가능 여부 조회 API, 비회원 예매 요청 API 추가

### DIFF
--- a/src/apis/domains/bookings/api.ts
+++ b/src/apis/domains/bookings/api.ts
@@ -3,23 +3,12 @@ import { components } from "@typings/api/schema";
 import { ApiResponseType } from "@typings/commonType";
 import { AxiosResponse } from "axios";
 
-export interface postGuestReq {
-  scheduleId: number;
-  purchaseTicketCount: number;
-  scheduleNumber: string;
-  bookerName: string;
-  bookerPhoneNumber: string;
-  birthDate: string;
-  password: string;
-  totalPaymentAmount: number;
-  isPaymentCompleted: boolean;
-}
-
+export type GuestBookingRequest = components["schemas"]["GuestBookingRequest"];
 type GuestBookingResponse = components["schemas"]["GuestBookingResponse"];
 
 // 1. API 요청 함수 작성 및 타입 추가
 export const postGuestBook = async (
-  formData: postGuestReq
+  formData: GuestBookingRequest
 ): Promise<GuestBookingResponse | null> => {
   try {
     const response: AxiosResponse<ApiResponseType<GuestBookingResponse>> = await post(

--- a/src/apis/domains/bookings/queries.ts
+++ b/src/apis/domains/bookings/queries.ts
@@ -1,5 +1,5 @@
 import { QueryClient, useMutation, useQuery } from "@tanstack/react-query";
-import { getGuestBookingList, postGuestBook, postGuestReq } from "./api";
+import { getGuestBookingList, GuestBookingRequest, postGuestBook } from "./api";
 
 export const QUERY_KEY = {
   LIST: "list",
@@ -10,7 +10,7 @@ export const useGuestBook = () => {
   const queryClient = new QueryClient();
 
   return useMutation({
-    mutationFn: (formData: postGuestReq) => postGuestBook(formData), // API 요청 함수
+    mutationFn: (formData: GuestBookingRequest) => postGuestBook(formData), // API 요청 함수
     onSuccess: (res) => {
       // 성공 시, 호출
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.LIST] });

--- a/src/apis/domains/performance/api.ts
+++ b/src/apis/domains/performance/api.ts
@@ -19,3 +19,21 @@ export const getBookingPerformanceDetail = async (
     return null;
   }
 };
+
+type TicketAvailabilityResponse = components["schemas"]["TicketAvailabilityResponse"];
+
+export const getScheduleAvailable = async (
+  scheduleId: number,
+  purchaseTicketCount: number
+): Promise<TicketAvailabilityResponse | null> => {
+  try {
+    const response: AxiosResponse<ApiResponseType<TicketAvailabilityResponse>> = await get(
+      `/schedules/${scheduleId}/availability?purchaseTicketCount=${purchaseTicketCount}`
+    );
+
+    return response.data.data;
+  } catch (error) {
+    console.error("error", error);
+    return null;
+  }
+};

--- a/src/apis/domains/performance/api.ts
+++ b/src/apis/domains/performance/api.ts
@@ -1,7 +1,8 @@
 import { get } from "@apis/index";
 import { components } from "@typings/api/schema";
 import { ApiResponseType } from "@typings/commonType";
-import { AxiosResponse } from "axios";
+import axios, { AxiosResponse } from "axios";
+
 
 type BookingPerformanceDetailResponse = components["schemas"]["BookingPerformanceDetailResponse"];
 
@@ -10,7 +11,7 @@ export const getBookingPerformanceDetail = async (
 ): Promise<BookingPerformanceDetailResponse | null> => {
   try {
     const response: AxiosResponse<ApiResponseType<BookingPerformanceDetailResponse>> = await get(
-      `/performances/detail/${performanceId}`
+      `/performances/booking/${performanceId}`
     );
 
     return response.data.data;
@@ -25,7 +26,7 @@ type TicketAvailabilityResponse = components["schemas"]["TicketAvailabilityRespo
 export const getScheduleAvailable = async (
   scheduleId: number,
   purchaseTicketCount: number
-): Promise<TicketAvailabilityResponse | null> => {
+): Promise<TicketAvailabilityResponse | number> => {
   try {
     const response: AxiosResponse<ApiResponseType<TicketAvailabilityResponse>> = await get(
       `/schedules/${scheduleId}/availability?purchaseTicketCount=${purchaseTicketCount}`
@@ -34,6 +35,14 @@ export const getScheduleAvailable = async (
     return response.data.data;
   } catch (error) {
     console.error("error", error);
-    return null;
+
+    if (axios.isAxiosError(error)) {
+      console.error("err is", error);
+      const errorStatus = error.response?.data.status;
+      console.log(errorStatus);
+
+      return errorStatus;
+    }
+    return -1;
   }
 };

--- a/src/apis/domains/performance/api.ts
+++ b/src/apis/domains/performance/api.ts
@@ -1,0 +1,21 @@
+import { get } from "@apis/index";
+import { components } from "@typings/api/schema";
+import { ApiResponseType } from "@typings/commonType";
+import { AxiosResponse } from "axios";
+
+type BookingPerformanceDetailResponse = components["schemas"]["BookingPerformanceDetailResponse"];
+
+export const getBookingPerformanceDetail = async (
+  performanceId: number
+): Promise<BookingPerformanceDetailResponse | null> => {
+  try {
+    const response: AxiosResponse<ApiResponseType<BookingPerformanceDetailResponse>> = await get(
+      `/performances/detail/${performanceId}`
+    );
+
+    return response.data.data;
+  } catch (error) {
+    console.error("error", error);
+    return null;
+  }
+};

--- a/src/apis/domains/performance/queries.ts
+++ b/src/apis/domains/performance/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getBookingPerformanceDetail } from "./api";
+import { getBookingPerformanceDetail, getScheduleAvailable } from "./api";
 
 export const QUERY_KEY = {
   DETAIL: "detail",
@@ -11,5 +11,13 @@ export const useGetBookingPerformanceDetail = (performanceId: number) => {
     queryFn: () => getBookingPerformanceDetail(performanceId),
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
+  });
+};
+
+export const useGetScheduleAvailable = (scheduleId: number, purchaseTicketCount: number) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.DETAIL, scheduleId],
+    queryFn: () => getScheduleAvailable(scheduleId, purchaseTicketCount),
+    enabled: false,
   });
 };

--- a/src/apis/domains/performance/queries.ts
+++ b/src/apis/domains/performance/queries.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getBookingPerformanceDetail } from "./api";
+
+export const QUERY_KEY = {
+  DETAIL: "detail",
+};
+
+export const useGetBookingPerformanceDetail = (performanceId: number) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.DETAIL, performanceId],
+    queryFn: () => getBookingPerformanceDetail(performanceId),
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+  });
+};

--- a/src/apis/domains/performance/queries.ts
+++ b/src/apis/domains/performance/queries.ts
@@ -3,11 +3,12 @@ import { getBookingPerformanceDetail, getScheduleAvailable } from "./api";
 
 export const QUERY_KEY = {
   DETAIL: "detail",
+  BOOKING_DETAIL: "bookingDetail",
 };
 
 export const useGetBookingPerformanceDetail = (performanceId: number) => {
   return useQuery({
-    queryKey: [QUERY_KEY.DETAIL, performanceId],
+    queryKey: [QUERY_KEY.BOOKING_DETAIL, performanceId],
     queryFn: () => getBookingPerformanceDetail(performanceId),
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,

--- a/src/components/commons/modal/components/ModalWrapper.styled.ts
+++ b/src/components/commons/modal/components/ModalWrapper.styled.ts
@@ -36,6 +36,9 @@ export const ModalTextWrapper = styled.section`
 export const ModalTitle = styled.span`
   ${({ theme }) => theme.fonts.heading4};
   color: ${({ theme }) => theme.colors.white};
+  white-space: pre-line;
+  text-align: center;
+
 `;
 
 //white-space : pre-line 을 사용하면 \n 을 인식가능.

--- a/src/pages/book/Book.tsx
+++ b/src/pages/book/Book.tsx
@@ -262,7 +262,10 @@ const Book = () => {
             ?.scheduleList![(selectedValue ?? 1) - 1].performanceDate?.slice(11, 16)
             .toString()}
         />
-        <Context subTitle="가격" text={`${(data?.ticketPrice ?? 0 * round).toLocaleString()}원`} />
+        <Context
+          subTitle="가격"
+          text={`${((data?.ticketPrice ?? 0) * round).toLocaleString()}원`}
+        />
         <Context subTitle="예매자" text={bookerInfo.bookerName} />
         <OuterLayout gap="1.1rem" margin="2.4rem 0 0 0">
           <Button variant="gray" size="medium" onClick={handleSheetClose}>

--- a/src/pages/book/components/bookerInfo/BookerInfo.tsx
+++ b/src/pages/book/components/bookerInfo/BookerInfo.tsx
@@ -23,6 +23,7 @@ const BookerInfo = ({ isNonMember, bookerInfo, onChangeBookerInfo }: BookerInfoP
         value={bookerInfo.bookerName}
         onChange={onChangeBookerInfo}
         placeholder="예매자(대표 예매자) 이름"
+        maxLength={5}
       />
       <TextField
         name="bookerPhoneNumber"
@@ -31,6 +32,7 @@ const BookerInfo = ({ isNonMember, bookerInfo, onChangeBookerInfo }: BookerInfoP
         onChange={onChangeBookerInfo}
         filter={phoneNumberFilter}
         placeholder="휴대폰 번호 (‘-’ 없이 입력)"
+        maxLength={13}
       />
       {isNonMember && (
         <TextField

--- a/src/pages/book/components/complete/Complete.tsx
+++ b/src/pages/book/components/complete/Complete.tsx
@@ -1,28 +1,30 @@
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader } from "@hooks/useHeader";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import FreeBook from "../freeBook/FreeBook";
 import PaidBook from "../paidBook/PaidBook";
 
 const Complete = () => {
+  const location = useLocation();
   const navigate = useNavigate();
-  const isPaid = false;
 
-  // TODO: state로 받아오기
-  const title = "비트 정기공연";
-  const bankName = "농협";
-  const accountNumber = "3561202376833";
-  const price = 10000;
-  const id = 1;
+  // TODO: 기본 값 수정
+  const {
+    id = 1,
+    title = "비트 정기공연",
+    bankName = "농협",
+    accountNumber = "3561202376833",
+    price = 100002,
+  } = location.state || {};
+
+  const isPaid = price !== 0 ? true : false;
 
   const { setHeader } = useHeader();
 
   useEffect(() => {
     setHeader({
       headerStyle: NAVIGATION_STATE.ICON,
-      title: "내가 등록한 공연",
-      subText: "삭제",
       rightOnClick: () => {
         navigate("/main");
       },
@@ -40,7 +42,7 @@ const Complete = () => {
           price={price}
         />
       ) : (
-        <FreeBook title={title} id={id} />
+        <FreeBook id={id} title={title} />
       )}
     </>
   );

--- a/src/pages/book/components/paidBook/PaidBook.tsx
+++ b/src/pages/book/components/paidBook/PaidBook.tsx
@@ -51,7 +51,7 @@ const PaidBook = ({ id, title, bankName, accountNumber, price }: PaidBookProps) 
         <S.Title>{`${title} \n예매가 완료되었어요!`}</S.Title>
         <Spacing marginBottom="1" />
 
-        <S.Description>어떻게 오셨어요? 비트 타고요.</S.Description>
+        <S.Description>입금자명은 예약자 이름과 동일하게 설정해주세요.</S.Description>
         <Spacing marginBottom="3.2" />
 
         <S.DepositContainer>

--- a/src/pages/book/components/select/RadioGroup.tsx
+++ b/src/pages/book/components/select/RadioGroup.tsx
@@ -8,8 +8,8 @@ const RadioGroup = ({ selectedValue, handleRadioChange, scheduleList }: SelectPr
       {scheduleList.map((schedule, i) => (
         <RadioButton
           key={`schedule-${i}`}
-          label={schedule.performanceDate}
-          value={schedule.scheduleId}
+          label={schedule.performanceDate ?? ""}
+          value={schedule.scheduleId ?? 0}
           checked={selectedValue === schedule.scheduleId}
           isSoldOut={schedule.availableTicketCount === 0}
           onChange={handleRadioChange}

--- a/src/pages/book/components/select/Select.tsx
+++ b/src/pages/book/components/select/Select.tsx
@@ -1,15 +1,17 @@
 import RadioGroup from "./RadioGroup";
 import * as S from "./Select.styled";
 
+export interface ScheduleListTypes {
+  scheduleId?: number;
+  performanceDate?: string;
+  availableTicketCount?: number;
+  scheduleNumber?: string;
+}
+
 export interface SelectProps {
   selectedValue: number;
   handleRadioChange: (value: number) => void;
-  scheduleList: {
-    scheduleId?: number;
-    performanceDate?: string;
-    availableTicketCount?: number;
-    scheduleNumber?: string;
-  }[];
+  scheduleList: ScheduleListTypes[];
 }
 
 const Select = ({ selectedValue, handleRadioChange, scheduleList }: SelectProps) => {

--- a/src/pages/book/components/select/Select.tsx
+++ b/src/pages/book/components/select/Select.tsx
@@ -5,10 +5,10 @@ export interface SelectProps {
   selectedValue: number;
   handleRadioChange: (value: number) => void;
   scheduleList: {
-    scheduleId: number;
-    performanceDate: string;
-    availableTicketCount: number;
-    scheduleNumber: string;
+    scheduleId?: number;
+    performanceDate?: string;
+    availableTicketCount?: number;
+    scheduleNumber?: string;
   }[];
 }
 

--- a/src/pages/book/typings/formData.ts
+++ b/src/pages/book/typings/formData.ts
@@ -1,6 +1,6 @@
 export interface FormData {
   scheduleId: string | undefined;
-  selectedValue: number | undefined;
+  scheduleNumber: number | undefined;
   purchaseTicketCount: number;
   totalPaymentAmount: number;
   bookerName: string;

--- a/src/pages/book/utils/index.ts
+++ b/src/pages/book/utils/index.ts
@@ -1,0 +1,10 @@
+import { ScheduleListTypes } from "../components/select/Select";
+
+export const getScheduleNumberById = (
+  scheduleList: ScheduleListTypes[],
+  scheduleId: number
+): string | undefined => {
+  const schedule = scheduleList.find((item) => item.scheduleId === scheduleId);
+
+  return schedule ? schedule.scheduleNumber : undefined;
+};


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #192 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 예매 관련 공연 정보 조회 API 추가
2. 티켓 예매 가능 여부 조회 API 추가
3. 비회원 예매 요청 API 추가

## 📢 To Reviewers

- book 페이지에서 토큰을 가지고 하는 회원 예매 요청 API 제외 추가했습니다.
- 토큰 관련 로직이 서버에서 구현되면 회원 예매 요청도 바로 시작하겠읍니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
