### PR TITLE
[Feat/#210] 수정 시 공연 정보 조회 API (GET) 연결 

### DIFF
--- a/src/apis/domains/performances/api.ts
+++ b/src/apis/domains/performances/api.ts
@@ -20,4 +20,16 @@ export const getMakerPerformance = async (): Promise<MakerPerformanceResponse | 
 // 공연 수정 페이지 정보 조회 API (GET)
 type PerformanceEditResponse = components["schemas"]["PerformanceEditResponse"];
 
-export const getPerformanceEdit = async () : Promise<>
+export const getPerformanceEdit = async (
+  performanceId: number
+): Promise<PerformanceEditResponse | null> => {
+  try {
+    const response: AxiosResponse<ApiResponseType<PerformanceEditResponse>> = await get(
+      `performances/${performanceId}`
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log("error", error);
+    return null;
+  }
+};

--- a/src/apis/domains/performances/api.ts
+++ b/src/apis/domains/performances/api.ts
@@ -16,3 +16,8 @@ export const getMakerPerformance = async (): Promise<MakerPerformanceResponse | 
     return null;
   }
 };
+
+// 공연 수정 페이지 정보 조회 API (GET)
+type PerformanceEditResponse = components["schemas"]["PerformanceEditResponse"];
+
+export const getPerformanceEdit = async () : Promise<>

--- a/src/apis/domains/performances/queries.ts
+++ b/src/apis/domains/performances/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getMakerPerformance } from "./api";
+import { getMakerPerformance, getPerformanceEdit } from "./api";
 
 const QUERY_KEY = {
   LIST: "list",
@@ -10,6 +10,16 @@ export const useMakerPerformance = () => {
   return useQuery({
     queryKey: [QUERY_KEY.LIST],
     queryFn: getMakerPerformance,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+  });
+};
+
+// 공연 수정 페이지 정보 조회 API (GET) 를 위한 쿼리 작성
+export const usePerformanceEdit = (performanceId: number) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.LIST],
+    queryFn: () => getPerformanceEdit(performanceId),
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });

--- a/src/components/commons/bank/InputBank.tsx
+++ b/src/components/commons/bank/InputBank.tsx
@@ -15,6 +15,7 @@ const InputBank = ({ isDisabled, bankOpen, onClick, children }: InputBankProps) 
       onClick();
     }
   };
+
   return (
     <S.InputBank
       $isDisabled={isDisabled}

--- a/src/pages/MyRegisterdShow/MyRegisterdShow.tsx
+++ b/src/pages/MyRegisterdShow/MyRegisterdShow.tsx
@@ -36,6 +36,10 @@ const MyRegisterdShow = () => {
   useEffect(() => {
     setShowList(data?.performances);
   }, [data]);
+
+  useEffect(() => {
+    console.log("showList: ", showList);
+  }, [showList]);
   const [isNothing, setIsNothing] = useState(true);
 
   useEffect(() => {
@@ -96,6 +100,7 @@ const MyRegisterdShow = () => {
                     performancePeriod={item.performancePeriod}
                     genre={item.genre}
                     posterImage={item.posterImage}
+                    param={item.performanceId}
                   />
                 ))}
               </S.RegisteredCardWrapper>

--- a/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
+++ b/src/pages/gig/components/makerIntroduce/MakerIntroduce.tsx
@@ -9,7 +9,8 @@ interface MakerIntroduceProps {
 }
 
 const MakerIntroduce = ({ teamName, castList, staffList }: MakerIntroduceProps) => {
-  console.log(castList);
+  console.log("ho", castList);
+  console.log("ho", staffList);
   return (
     <S.Wrapper>
       <S.Title>{teamName}</S.Title>

--- a/src/pages/gig/components/showInfo/ShowInfo.tsx
+++ b/src/pages/gig/components/showInfo/ShowInfo.tsx
@@ -6,7 +6,7 @@ import IconText from "../iconText/IconText";
 import ShowType from "../showType/ShowType";
 import * as S from "./ShowInfo.styled";
 
-type SchelduleListType = {
+export type SchelduleListType = {
   scheduleId: number;
   performanceDate: string;
   scheduleNumber: number;

--- a/src/pages/modifyManage/ModifyMaker.tsx
+++ b/src/pages/modifyManage/ModifyMaker.tsx
@@ -63,9 +63,11 @@ const ModifyManageMaker = ({
     const filteredCastList = castList.filter(
       (cast) => cast.castName || cast.castRole || cast.castPhoto
     );
+    console.log("필터캐스트:", filteredCastList);
     const filteredStaffList = staffList.filter(
       (staff) => staff.staffName || staff.staffRole || staff.staffPhoto
     );
+    console.log("필터스태프:", filteredStaffList);
 
     updateGigInfo({ castList: filteredCastList, staffList: filteredStaffList });
     handleModifyManageStep();

--- a/src/pages/modifyManage/ModifyManage.styled.ts
+++ b/src/pages/modifyManage/ModifyManage.styled.ts
@@ -263,3 +263,11 @@ export const PreviewBanner = styled.div`
   ${({ theme }) => theme.fonts["caption1-medi"]}
   background:  rgb(15 15 15 / 70%);
 `;
+
+export const NoContentBox = styled.p`
+  padding: 2.6rem 0;
+
+  color: ${({ theme }) => theme.colors.gray_500};
+  ${({ theme }) => theme.fonts["body2-normal-medi"]};
+  text-align: center;
+`;

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -1,3 +1,4 @@
+import { usePerformanceEdit } from "@apis/domains/performances/queries";
 import { IconChecked } from "@assets/svgs";
 import BankBottomSheet from "@components/commons/bank/bottomSheet/BankBottomSheet";
 import InputAccountWrapper from "@components/commons/bank/InputAccountWrapper";
@@ -8,14 +9,14 @@ import TextField from "@components/commons/input/textField/TextField";
 import Spacing from "@components/commons/spacing/Spacing";
 import Stepper from "@components/commons/stepper/Stepper";
 import TimePicker from "@components/commons/timepicker/TimePicker";
-import { BANK_LIST, BankListTypes } from "@constants/bankList";
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import useModal from "@hooks/useModal";
 import Content from "@pages/gig/components/content/Content";
-import ShowInfo from "@pages/gig/components/showInfo/ShowInfo";
+import ShowInfo, { SchelduleListType } from "@pages/gig/components/showInfo/ShowInfo";
 import { numericFilter, phoneNumberFilter, priceFilter } from "@utils/useInputFilter";
-import { ChangeEvent, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { useHeader } from "./../../hooks/useHeader";
 import GenreSelect from "./components/GenreSelect";
 import InputModifyManageBox from "./components/InputModifyManage";
@@ -25,7 +26,7 @@ import TimePickerModifyManageBox from "./components/TimePickerModifyManageBox";
 import { GENRE_LIST, GET_MODIFY_MANAGE_RESPONSE } from "./constants/genreList";
 import ModifyManageMaker from "./ModifyMaker";
 import * as S from "./ModifyManage.styled";
-import { Cast, DataProps, Staff } from "./typings/gigInfo";
+import { Cast, DataProps, Schedule, Staff } from "./typings/gigInfo";
 import {
   handleBankClick,
   handleBankOpen,
@@ -45,8 +46,17 @@ const ModifyManage = () => {
   const { openConfirm, closeConfirm, openAlert, closeAlert } = useModal();
   // gigInfo 초기화
   const [gigInfo, setGigInfo] = useState<DataProps>(GET_MODIFY_MANAGE_RESPONSE.data);
+  const { performanceId } = useParams();
 
+  const { data, isLoading } = usePerformanceEdit(Number(performanceId));
+
+  useEffect(() => {
+    setGigInfo(data as DataProps);
+  }, [data]);
+
+  /*
   // 구조 분해 할당
+
   const {
     performanceTitle,
     genre,
@@ -68,7 +78,77 @@ const ModifyManage = () => {
     isBookerExist,
     accountHolder,
   } = gigInfo;
+   */
 
+  let performanceTitle: string | undefined,
+    genre: "BAND" | "DANCE" | "PLAY" | "ETC" | string | undefined,
+    runningTime: number | null | undefined,
+    performanceDescription: string | undefined,
+    performanceAttentionNote: string | undefined,
+    accountNumber: string | undefined,
+    posterImage: string | undefined,
+    performanceTeamName: string | undefined,
+    performanceVenue: string | undefined,
+    performancePeriod: string | undefined,
+    performanceContact: string | undefined,
+    ticketPrice: number | undefined,
+    totalScheduleCount: number | undefined,
+    scheduleList: Schedule[] | undefined,
+    castList: Cast[] | undefined,
+    staffList: Staff[] | undefined,
+    bankName: string | undefined,
+    isBookerExist: boolean | undefined,
+    accountHolder: string | undefined;
+
+  if (gigInfo) {
+    performanceTitle = gigInfo.performanceTitle;
+    genre = gigInfo.genre;
+    runningTime = gigInfo.runningTime;
+    performanceDescription = gigInfo.performanceDescription;
+    performanceAttentionNote = gigInfo.performanceAttentionNote;
+    accountNumber = gigInfo.accountNumber;
+    posterImage = gigInfo.posterImage;
+    performanceTeamName = gigInfo.performanceTeamName;
+    performanceVenue = gigInfo.performanceVenue;
+    performancePeriod = gigInfo.performancePeriod;
+    performanceContact = gigInfo.performanceContact;
+    ticketPrice = gigInfo.ticketPrice;
+    totalScheduleCount = gigInfo.totalScheduleCount;
+    scheduleList = gigInfo.scheduleList;
+    if (gigInfo.castList.length === 0) {
+      castList = [
+        {
+          castId: -1,
+          castName: "", // 이름
+          castRole: "", // 역할
+          castPhoto: "", // 출연진 사진 URL
+        },
+      ];
+    } else {
+      castList = gigInfo.castList;
+    }
+    if (gigInfo.staffList.length === 0) {
+      staffList = [
+        {
+          staffId: -1,
+          staffName: "", // 이름
+          staffRole: "", // 역할
+          staffPhoto: "", // 출연진 사진 URL
+        },
+      ];
+    } else {
+      staffList = gigInfo.staffList;
+    }
+
+    bankName = gigInfo.bankName;
+    isBookerExist = gigInfo.isBookerExist;
+    accountHolder = gigInfo.accountHolder;
+  }
+
+  console.log(castList, staffList);
+  useEffect(() => {
+    console.log("스탭:", castList, staffList);
+  }, [castList, staffList]);
   const [bankOpen, setBankOpen] = useState(false);
   const [bankInfo, setBankInfo] = useState(bankName); //가져온 은행 이름으로 초기화
   const [isChecked, setIsChecked] = useState(true); //처음 가져오는 거니까 그냥 체크된 상태로 시작
@@ -112,6 +192,7 @@ const ModifyManage = () => {
   }, [ticketPrice]);
 
   const updateGigInfo = (newInfo: Partial<{ castList: Cast[]; staffList: Staff[] }>) => {
+    console.log("mew", newInfo);
     setGigInfo((prev) => ({
       ...prev,
       ...newInfo,
@@ -144,7 +225,7 @@ const ModifyManage = () => {
     }
   };
 
-  const handleDeletePerformance = (performanceId: number, isExisttt: boolean) => {
+  const handleDeletePerformance = (_performanceId: number, isExisttt: boolean) => {
     //사용자가 한명 이상 있으면 안된다는 문구 띄움 - 동훈이가 수정 시 공연 정보 조회 API (GET)에 COUNT나 bookingList를 넘겨줄 듯
     if (isExisttt) {
       openAlert({
@@ -166,7 +247,7 @@ const ModifyManage = () => {
       okText: "삭제할게요",
       okCallback: () => {
         //공연 수정 DELETE API 요청 쏘는 로직 존재할 예정
-        handleDeletePerformance(1, isExist); //예시로 박아둠
+        handleDeletePerformance(1, isExist as boolean); //예시로 박아둠
       },
       noText: "아니요",
       noCallback: () => {
@@ -191,13 +272,9 @@ const ModifyManage = () => {
     });
   }, [setHeader, ModifyManageStep]);
 
-  //해당 뱅크 영어 이름(api 통신 때의 값)에 객체의 한글 이름을 뽑아내어주는 함수
-  const getBankNameKr = (bankInfooo: string, BANK_LISTTT: BankListTypes) => {
-    const bank = BANK_LISTTT.find((obj) => obj.name === bankInfooo);
-    return bank ? bank.nameKr : "에러";
-  };
+  console.log("non state", staffList);
 
-  if (ModifyManageStep === 1) {
+  if (ModifyManageStep === 1 && gigInfo) {
     return (
       <>
         <S.ModifyManageContainer>
@@ -209,7 +286,7 @@ const ModifyManage = () => {
           <GenreSelect
             title="공연 장르"
             genres={GENRE_LIST}
-            selectedGenre={genre}
+            selectedGenre={genre as string}
             onGenreSelect={(selectedGenre) => handleGenreSelect(selectedGenre, setGigInfo)}
             marginBottom={2.4}
           />
@@ -266,19 +343,19 @@ const ModifyManage = () => {
           <StepperModifyManageBox title="회차 수" description="최대 3회차">
             <Stepper
               max={3}
-              round={totalScheduleCount}
+              round={totalScheduleCount as number}
               onMinusClick={() => onMinusClick(setGigInfo)}
               onPlusClick={() => onPlusClick(setGigInfo)}
             />
           </StepperModifyManageBox>
           <S.Divider />
           <TimePickerModifyManageBox title="회차별 시간대">
-            {scheduleList.map((schedule, index) => (
+            {scheduleList?.map((schedule, index) => (
               <div key={index}>
                 <S.InputDescription>{index + 1}회차</S.InputDescription>
                 <Spacing marginBottom={"1"} />
                 <TimePicker
-                  value={schedule.performanceDate}
+                  value={dayjs(schedule.performanceDate)}
                   onChangeValue={(date) => handleDateChange(index, date, setGigInfo)}
                 />
               </div>
@@ -304,7 +381,7 @@ const ModifyManage = () => {
               isDisabled={false}
               type="input"
               name="totalTicketCount"
-              value={scheduleList[0].totalTicketCount}
+              value={scheduleList?.[0].totalTicketCount}
               onChange={(e) => handleTotalTicketCountChange(e, setGigInfo)}
               placeholder="판매할 티켓의 매 수를 입력해주세요."
               filter={numericFilter}
@@ -323,7 +400,7 @@ const ModifyManage = () => {
           </InputModifyManageBox>
           <S.Divider />
           <InputModifyManageBox
-            isDisabled={isExist}
+            isDisabled={isExist as boolean}
             title="티켓 가격"
             description="*티켓 가격은 수정불가합니다."
             isFree={isFree}
@@ -346,11 +423,11 @@ const ModifyManage = () => {
             <>
               <InputAccountWrapper>
                 <InputBank
-                  isDisabled={isExist}
+                  isDisabled={isExist as boolean}
                   bankOpen={bankOpen}
                   onClick={() => handleBankOpen(setBankOpen)}
                 >
-                  {getBankNameKr(bankInfo, BANK_LIST)}
+                  {bankInfo as string}
                 </InputBank>
                 <TextField
                   isDisabled={isExist}
@@ -374,8 +451,15 @@ const ModifyManage = () => {
             </>
           )}
           <BankBottomSheet
-            value={bankInfo}
-            onBankClick={(value) => handleBankClick(value, setGigInfo, setBankInfo, setBankOpen)}
+            value={bankInfo as string}
+            onBankClick={(value) =>
+              handleBankClick(
+                value,
+                setGigInfo,
+                setBankInfo as Dispatch<SetStateAction<string>>,
+                setBankOpen
+              )
+            }
             isOpen={bankOpen}
             onOutClick={() => handleBankOpen(setBankOpen)}
           />
@@ -407,7 +491,7 @@ const ModifyManage = () => {
           </S.CheckboxContainer>
           <Button
             onClick={handleModifyManageStep}
-            disabled={!isAllFieldsFilled(gigInfo, isFree) || !isChecked}
+            disabled={!isAllFieldsFilled(gigInfo as DataProps, isFree) || !isChecked}
           >
             다음
           </Button>
@@ -419,45 +503,54 @@ const ModifyManage = () => {
   if (ModifyManageStep === 2) {
     return (
       <ModifyManageMaker
-        castList={castList}
-        staffList={staffList}
+        castList={castList as Cast[]}
+        staffList={staffList as Staff[]}
         handleModifyManageStep={handleModifyManageStep}
         updateGigInfo={updateGigInfo}
       />
     );
   }
-
   if (ModifyManageStep === 3) {
     return (
       <>
         <ShowInfo
-          posterImage={posterImage}
-          title={performanceTitle}
-          price={ticketPrice}
-          venue={performanceVenue}
-          period={performancePeriod}
-          runningTime={runningTime}
-          genre={genre}
+          posterImage={posterImage as string}
+          title={performanceTitle as string}
+          price={ticketPrice as number}
+          venue={performanceVenue as string}
+          period={performancePeriod as string}
+          runningTime={runningTime as number}
+          genre={genre as "BAND" | "DANCE" | "PLAY" | "ETC"}
           // 타임존 안맞아서 지금 날짜 안맞는데 로컬 타임존으로 보이게 설정하면 기간 잘 맞아요!
-          scheduleList={scheduleList.map((schedule, index) => ({
-            scheduleId: index + 1,
-            performanceDate: schedule.performanceDate?.toString() || "",
-            scheduleNumber: index + 1,
-          }))}
+          scheduleList={
+            scheduleList?.map((schedule, index) => ({
+              scheduleId: index + 1,
+              performanceDate: schedule.performanceDate?.toString() || "",
+              scheduleNumber: index + 1,
+            })) as SchelduleListType[]
+          }
         />
         <Content
-          description={performanceDescription}
-          attentionNote={performanceAttentionNote}
-          contact={performanceContact}
-          teamName={performanceTeamName}
-          castList={castList.map((cast, index) => ({
-            ...cast,
-            castId: index + 1,
-          }))}
-          staffList={staffList.map((cast, index) => ({
-            ...cast,
-            staffId: index + 1,
-          }))}
+          description={performanceDescription as string}
+          attentionNote={performanceAttentionNote as string}
+          contact={performanceContact as string}
+          teamName={performanceTeamName as string}
+          castList={
+            castList?.[0].castId === -1
+              ? []
+              : (castList?.map((cast, index) => ({
+                  ...cast,
+                  castId: index + 1,
+                })) as Cast[])
+          }
+          staffList={
+            staffList?.[0].staffId === -1
+              ? []
+              : (staffList?.map((cast, index) => ({
+                  ...cast,
+                  staffId: index + 1,
+                })) as Staff[])
+          }
         />
         <S.FooterContainer>
           <Button onClick={handleComplete}>완료하기</Button>

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -157,7 +157,8 @@ const ModifyManage = () => {
   const navigate = useNavigate();
 
   const handleComplete = () => {
-    navigate("/ModifyManage-complete");
+    console.log("gigInfo:", gigInfo);
+    //navigate("/ModifyManage-complete");
   };
 
   // 약관 동의

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -38,7 +38,7 @@ const router = createBrowserRouter([
       { path: "manage", element: <Manage /> },
       { path: "gig-manage", element: <MyRegisterdShow /> },
       { path: "guest-manage/:performanceId", element: <TicketHolderList /> },
-      { path: "gig-modify-manage", element: <ModifyManage /> },
+      { path: "gig-modify-manage/:performanceId", element: <ModifyManage /> },
 
       // ... other pages
     ],

--- a/src/typings/api/schema/index.ts
+++ b/src/typings/api/schema/index.ts
@@ -17,8 +17,8 @@ export interface paths {
      */
     get: operations["getTickets"];
     /**
-     * 예매자 입금여부 수정 API
-     * @description 메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정하는 PUT API입니다.
+     * 예매자 입금여부 수정 및 웹발신 API
+     * @description 메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.
      */
     put: operations["updateTickets"];
     post?: never;
@@ -27,6 +27,30 @@ export interface paths {
      * @description 메이커가 자신의 공연에 대한 예매자의 정보를 삭제하는 DELETE API입니다.
      */
     delete: operations["deleteTickets"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * 공연 정보 수정 API
+     * @description 공연 정보를 수정하는 PUT API입니다.
+     */
+    put: operations["updatePerformance"];
+    /**
+     * 공연 생성 API
+     * @description 공연을 생성하는 POST API입니다.
+     */
+    post: operations["createPerformance"];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -132,6 +156,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/health-check": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["healthcheck"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/users/refresh-token": {
     parameters: {
       query?: never;
@@ -163,6 +203,30 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances/{performanceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 공연 수정 페이지 정보 조회 API
+     * @description 공연 정보를 조회하는 GET API입니다.
+     */
+    get: operations["getPerformanceForEdit"];
+    put?: never;
+    post?: never;
+    /**
+     * 공연 삭제 API
+     * @description 공연을 삭제하는 DELETE API입니다.
+     */
+    delete: operations["deletePerformance"];
     options?: never;
     head?: never;
     patch?: never;
@@ -300,6 +364,145 @@ export interface components {
       message?: string;
       data?: Record<string, never>;
     };
+    CastUpdateRequest: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceUpdateRequest: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleUpdateRequest"][];
+      castList?: components["schemas"]["CastUpdateRequest"][];
+      staffList?: components["schemas"]["StaffUpdateRequest"][];
+    };
+    ScheduleUpdateRequest: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      scheduleNumber?: string;
+    };
+    StaffUpdateRequest: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    CastUpdateResponse: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceUpdateResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleUpdateResponse"][];
+      castList?: components["schemas"]["CastUpdateResponse"][];
+      staffList?: components["schemas"]["StaffUpdateResponse"][];
+    };
+    ScheduleUpdateResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffUpdateResponse: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    SuccessResponsePerformanceUpdateResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceUpdateResponse"];
+    };
     MemberLoginRequest: {
       /** @enum {string} */
       socialType: "KAKAO";
@@ -314,6 +517,140 @@ export interface components {
       status?: number;
       message?: string;
       data?: components["schemas"]["LoginSuccessResponse"];
+    };
+    CastRequest: {
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceRequest: {
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleRequest"][];
+      castList?: components["schemas"]["CastRequest"][];
+      staffList?: components["schemas"]["StaffRequest"][];
+    };
+    ScheduleRequest: {
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffRequest: {
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    CastResponse: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleResponse"][];
+      castList?: components["schemas"]["CastResponse"][];
+      staffList?: components["schemas"]["StaffResponse"][];
+    };
+    ScheduleResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffResponse: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    SuccessResponsePerformanceResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceResponse"];
     };
     MemberBookingRequest: {
       /** Format: int64 */
@@ -482,6 +819,57 @@ export interface components {
       requestedTicketCount?: number;
       isAvailable?: boolean;
     };
+    PerformanceEditResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      isBookerExist?: boolean;
+      scheduleList?: components["schemas"]["ScheduleResponse"][];
+      castList?: components["schemas"]["CastResponse"][];
+      staffList?: components["schemas"]["StaffResponse"][];
+    };
+    SuccessResponsePerformanceEditResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceEditResponse"];
+    };
     MakerPerformanceDetail: {
       /** Format: int64 */
       performanceId?: number;
@@ -560,6 +948,9 @@ export interface components {
       posterImage?: string;
       performanceVenue?: string;
       performanceTeamName?: string;
+      bankName?: string;
+      accountNumber?: string;
+      accountHolder?: string;
     };
     BookingPerformanceDetailSchedule: {
       /** Format: int64 */
@@ -733,6 +1124,58 @@ export interface operations {
       };
     };
   };
+  updatePerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PerformanceUpdateRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceUpdateResponse"];
+        };
+      };
+    };
+  };
+  createPerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PerformanceRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceResponse"];
+        };
+      };
+    };
+  };
   signUp: {
     parameters: {
       query: {
@@ -853,6 +1296,26 @@ export interface operations {
       };
     };
   };
+  healthcheck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
   refreshToken: {
     parameters: {
       query: {
@@ -895,6 +1358,54 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["SuccessResponseTicketAvailabilityResponse"];
+        };
+      };
+    };
+  };
+  getPerformanceForEdit: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceEditResponse"];
+        };
+      };
+    };
+  };
+  deletePerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseVoid"];
         };
       };
     };


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #210 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- 수정시 공연 정보 조회 API
- response에 따라 undefined가 될 수 있어 조건부 렌더링하도록 if문을 추가하여 6시간만에 겨우.. 해결했습니다.
- 이런 저런 시도를 하다가 결국 최종본으로 reset을 해놓아서, 이번에만 브랜치명이 backup으로 시작합니다.. 죄송합니다 ㅜㅜ
- backup 브랜치는 기존 feat/#210/performanceAPI2 에서 브랜치를 하나 파서 PUSH 해둔 것입니다.
- put 요청 보내기 전에 콘솔 찍도록 구현해놓았습니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
