### PR TITLE
[ Bug/#256 ] 예매 완료 페이지 + 공연 상세 페이지 QA 반영

### DIFF
--- a/src/pages/book/components/paidBook/PaidBook.styled.ts
+++ b/src/pages/book/components/paidBook/PaidBook.styled.ts
@@ -2,6 +2,10 @@ import { IcomCopy } from "@assets/svgs";
 import styled from "styled-components";
 
 export const Wrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-height: calc(100vh - 156px);
   padding: 0 2.4rem 2.4rem;
 `;

--- a/src/pages/book/components/paidBook/PaidBook.styled.ts
+++ b/src/pages/book/components/paidBook/PaidBook.styled.ts
@@ -42,6 +42,7 @@ export const GigText = styled.p`
 `;
 
 export const DepositContainer = styled.section`
+  width: 100%;
   padding: 20px 16px;
 
   background: ${({ theme }) => theme.colors.gray_800};

--- a/src/pages/gig/components/performanceIntroduce/Contact.tsx
+++ b/src/pages/gig/components/performanceIntroduce/Contact.tsx
@@ -28,7 +28,12 @@ const Contact = ({ contact }: ContactProps) => {
         <S.Title>문의 연락처</S.Title>
         <S.Toggle onClick={handleToggle}>{toggle ? <IconArrowUp /> : <IconArrowDown />}</S.Toggle>
       </S.ContactTitleBox>
-      {toggle && <S.Contact onClick={() => handleCopyClipBoard(contact)}>{contact}</S.Contact>}
+      {toggle && (
+        <S.Contact onClick={() => handleCopyClipBoard(contact)}>
+          {contact}
+          <S.IconCopy $width={24} $height={24} />
+        </S.Contact>
+      )}
       <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={100}>
         클립보드에 복사되었습니다!
       </Toast>

--- a/src/pages/gig/components/performanceIntroduce/Contact.tsx
+++ b/src/pages/gig/components/performanceIntroduce/Contact.tsx
@@ -29,7 +29,7 @@ const Contact = ({ contact }: ContactProps) => {
         <S.Toggle onClick={handleToggle}>{toggle ? <IconArrowUp /> : <IconArrowDown />}</S.Toggle>
       </S.ContactTitleBox>
       {toggle && <S.Contact onClick={() => handleCopyClipBoard(contact)}>{contact}</S.Contact>}
-      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={100}>
         클립보드에 복사되었습니다!
       </Toast>
     </S.ContactContainer>

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
@@ -1,3 +1,4 @@
+import { IcomCopy } from "@assets/svgs";
 import styled from "styled-components";
 
 export const Wrapper = styled.section`
@@ -57,9 +58,17 @@ export const Contact = styled.p`
   width: 100%;
   padding: 1.2rem 1.2rem 1.2rem 0;
   text-decoration-line: underline;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 
   color: ${({ theme }) => theme.colors.white};
 
   ${({ theme }) => theme.fonts["body2-long"]};
   cursor: pointer;
+`;
+
+export const IconCopy = styled(IcomCopy)<{ $width: number; $height: number }>`
+  width: ${({ $width }) => `${$width}px`};
+  height: ${({ $height }) => `${$height}px`};
 `;

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
@@ -56,7 +56,7 @@ export const Toggle = styled.span`
 export const Contact = styled.p`
   width: 100%;
   padding: 1.2rem 1.2rem 1.2rem 0;
-  text-decoration-line: underline;
+  text-decoration-line: none;
 
   color: ${({ theme }) => theme.colors.white};
 

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
@@ -56,7 +56,7 @@ export const Toggle = styled.span`
 export const Contact = styled.p`
   width: 100%;
   padding: 1.2rem 1.2rem 1.2rem 0;
-  text-decoration-line: none;
+  text-decoration-line: underline;
 
   color: ${({ theme }) => theme.colors.white};
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #265 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

- 예매 완료 페이지 얼라인 중앙으로 맞춤
- 공연 상세페이지 하단에 문의하기 전화번호 → 토스트도 뜨게 만듬
- 상세 페이지 토스트 아이콘 추가
- 공연 상세페이지 뷰에서 ‘문의 연락처’ 언더라인 유지

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
