### PR TITLE
refactor: remove qs and replace with URLSearchParams Web API

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lottie-react": "^2.4.0",
     "postcss": "^8.4.38",
     "postcss-scss": "^4.0.9",
-    "qs": "^6.12.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-lottie-player": "^2.0.0",

--- a/src/apis/domains/files/api.ts
+++ b/src/apis/domains/files/api.ts
@@ -1,6 +1,5 @@
 import { get } from "@apis/index";
 import axios, { AxiosResponse } from "axios";
-import qs from "qs";
 
 interface ImageInterface {
   [key: string]: string;

--- a/src/apis/domains/files/api.ts
+++ b/src/apis/domains/files/api.ts
@@ -31,9 +31,13 @@ export const getPresignedUrl = async (
     const response: AxiosResponse<PresignedResponse> = await get("/files/presigned-url", {
       params: paramsWithEmptyArrays,
       paramsSerializer: (params) => {
-        const queryString = qs.stringify(params, { arrayFormat: "repeat" });
+        const searchParams = new URLSearchParams();
 
-        const modifiedQueryString = queryString
+        for (const [k, v] of Object.entries(params)) {
+          searchParams.set(k, v);
+        }
+
+        const modifiedQueryString = searchParams.toString()
           .replace(/castImages=%5B%5D/g, "castImages")
           .replace(/staffImages=%5B%5D/g, "staffImages");
         return modifiedQueryString;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,7 +4914,6 @@ __metadata:
     postcss-styled-syntax: "npm:^0.6.4"
     prettier: "npm:^3.3.2"
     prettier-linter-helpers: "npm:^1.0.0"
-    qs: "npm:^6.12.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-lottie-player: "npm:^2.0.0"
@@ -9801,15 +9800,6 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.0.4"
   checksum: 10c0/4e4875e4d7c7c31c233d07a448e7e4650f456178b9dd3766b7cfa13158fdb24ecb8c4f059fa91e820dc6ab9f2d243721d071c9c0378892dcdad86e9e9a27c68f
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.12.3":
-  version: 6.12.3
-  resolution: "qs@npm:6.12.3"
-  dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/243ddcc8f49dab78fc51041f7f64c500b47c671c45a101a8aca565d8537cb562921da7ef1a831b4a7051596ec88bb35a0d5e25a240025e8b32c6bfb69f00bf2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

- `qs` 라이브러리 사용을 제거하고, `URLSearchParams()` 패키지로 변경합니다.
  - 웹 표준 API를 사용합니다.
  - qs를 제거해 번들사이즈를 최적화합니다.
    - https://bundlephobia.com/package/qs@6.12.3
  - 동작시켜보질 않아서;; 테스트 한번 해보시면 좋을거같아요.