### PR TITLE
[Fix/#306] 메인에 종료된 공연 표시 및 라벨링

### DIFF
--- a/src/components/commons/label/Labal.tsx
+++ b/src/components/commons/label/Labal.tsx
@@ -2,29 +2,31 @@ import { ReactNode } from "react";
 import * as S from "./Label.styled";
 
 interface LabelProps {
-  type: "count" | "finish" | "today";
-  children: ReactNode;
+  dueDate: number;
 }
 
-const Labal = ({ type, children }: LabelProps) => {
+const Labal = ({ dueDate }: LabelProps) => {
   return (
     <S.LabelWrapper>
-      {type === "count" ? (
-        <>
-          <S.CountLabel />
-          <S.CountDueDate>{children}</S.CountDueDate>
-        </>
-      ) : type === "finish" ? (
-        <>
-          <S.FinishLabel />
-          <S.FinishDueDate>{children}</S.FinishDueDate>
-        </>
-      ) : (
+      {dueDate === 0 && (
         <>
           <S.TodayLabel />
-          <S.CountDueDate>{children}</S.CountDueDate>
+          <S.CountDueDate>D-DAY</S.CountDueDate>
         </>
       )}
+      {dueDate < 0 && (
+        <>
+          <S.FinishLabel />
+          <S.FinishDueDate>공연종료</S.FinishDueDate>
+        </>
+      )}
+      {dueDate > 0 &&
+        (dueDate <= 5 ? (
+          <>
+            <S.CountLabel />
+            <S.CountDueDate>D-{dueDate}</S.CountDueDate>
+          </>
+        ) : null)}
     </S.LabelWrapper>
   );
 };

--- a/src/pages/lookup/components/LookupWrapper.tsx
+++ b/src/pages/lookup/components/LookupWrapper.tsx
@@ -2,14 +2,11 @@ import * as S from "./LookupWrapper.styled";
 
 import Button from "@components/commons/button/Button";
 import LookupCard from "./LookupCard";
-import { calculateDueDate } from "@utils/calculateDueDate";
 import Labal from "@components/commons/label/Labal";
 
 import { LookupProps } from "../types/lookupType";
 
 const LookupWrapper = ({ handleBtn, ...item }: LookupProps) => {
-  const dueDateText = calculateDueDate(item.dueDate);
-
   return (
     <S.LookupLayout>
       <S.LookupContainer>

--- a/src/pages/lookup/components/LookupWrapper.tsx
+++ b/src/pages/lookup/components/LookupWrapper.tsx
@@ -15,22 +15,7 @@ const LookupWrapper = ({ handleBtn, ...item }: LookupProps) => {
       <S.LookupContainer>
         <S.LookupCardLeft>
           <S.LookupImage src={item.posterImage} />
-          {item.dueDate >= 1 && item.dueDate <= 6 ? (
-            <>
-              <Labal type="count"> {dueDateText}</Labal>
-            </>
-          ) : item.dueDate === 0 ? (
-            <>
-              <Labal type="today"> {dueDateText}</Labal>
-            </>
-          ) : item.dueDate < 0 ? (
-            <>
-              <Labal type="finish"> {dueDateText}</Labal>
-            </>
-          ) : (
-            <></>
-          )}
-
+          <Labal dueDate={item.dueDate} />
           <Button variant="line" size="xsmall" onClick={handleBtn}>
             취소하기
           </Button>

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -29,12 +29,8 @@ const Performance = ({ genre, performanceList = [] }: PerformanceComponentProps)
   const filteredData =
     genre === "ALL" ? performanceList : performanceList.filter((item) => item.genre === genre);
 
-  const sortData = filteredData
-    .filter((item) => item.dueDate! >= 0)
-    .sort((a, b) => a.dueDate! - b.dueDate!);
-
-  const data1 = sortData.slice(0, 4);
-  const data2 = sortData.slice(4);
+  const data1 = filteredData.slice(0, 4);
+  const data2 = filteredData.slice(4);
 
   return (
     <S.PerformanceWrapper>

--- a/src/pages/main/components/performance/PerformnaceCard.tsx
+++ b/src/pages/main/components/performance/PerformnaceCard.tsx
@@ -2,7 +2,6 @@ import * as S from "./Performance.Cardstyled";
 import { useNavigate } from "react-router-dom";
 
 import Labal from "@components/commons/label/Labal";
-import { Label } from "@pages/book/components/select/RadioButton.styled";
 
 const PerformnaceCard = ({ ...item }) => {
   const navigate = useNavigate();
@@ -16,13 +15,7 @@ const PerformnaceCard = ({ ...item }) => {
     >
       <S.PerformanceImg src={item.posterImage} />
 
-      {item.dueDate <= 5 ? (
-        item.dueDate === 0 ? (
-          <Labal type="today">D-DAY</Labal>
-        ) : (
-          <Labal type="count">D-{item.dueDate}</Labal>
-        )
-      ) : null}
+      <Labal dueDate={item.dueDate} />
       <S.PerformanceTitleWrapper>
         <S.PerformanceTitle>{item.performanceTitle}</S.PerformanceTitle>
         <S.PerformancePeriod>{item.performancePeriod}</S.PerformancePeriod>

--- a/src/utils/calculateDueDate.ts
+++ b/src/utils/calculateDueDate.ts
@@ -1,9 +1,0 @@
-export const calculateDueDate = (dueDate: number) => {
-  if (dueDate <= 5 && dueDate >= 1) {
-    return `D-${dueDate}`;
-  } else if (dueDate < 0) {
-    return "공연종료";
-  } else if (dueDate === 0) {
-    return "D-DAY";
-  }
-};


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #306 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 리팩토링

## ✅ Key Changes

- [x] D-n 공연들은 공연일에 가까운 순으로 리스트업
- [x] 종료 공연들은 최근 공연 순으로 리스트업 - 이전에는 안 보이도록 되어 있었음
- [x] 라벨에서 날짜까지 계산할 수 있도록 컴포넌트 수정

## 📢 To Reviewers

- 이전에는 날짜 계산해서 텍스트로 반환하는 util 따로, Page에서 날짜 계산하는 거 따로, 라벨 컴포넌트 따로 있어서 너무 비효율적이라고 생각해서 Label 컴포넌트에서 날짜까지 계산하도록 수정하였습니다.
- props로 Label component에 dueDate만 넘겨주면 계산된 날짜에 맞는 라벨이 생깁니다! Page에서 따로 날짜 구분해 줄 필요 없어요!

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/21351b16-18ec-4e05-bd6c-b578958df93d)

