### PR TITLE
[Refactor/#333] image ratio 변경

### DIFF
--- a/src/pages/book/components/info/Info.styled.ts
+++ b/src/pages/book/components/info/Info.styled.ts
@@ -12,13 +12,11 @@ export const InfoTop = styled.div`
   display: flex;
 `;
 
-export const InfoPoster = styled.img<{ $imgsrc: string }>`
+export const InfoPoster = styled.img`
   width: 9.5rem;
   height: 12.8rem;
   margin-right: 1.4rem;
 
-  background-image: url(${({ $imgsrc }) => $imgsrc});
-  background-size: 100% 100%;
   border-radius: 4px;
 `;
 

--- a/src/pages/book/components/info/Info.tsx
+++ b/src/pages/book/components/info/Info.tsx
@@ -20,7 +20,7 @@ const Info = ({ genre, title, posterImage, teamName, venue, period }: InfoProps)
   return (
     <S.InfoContainer>
       <S.InfoTop>
-        <S.InfoPoster $imgsrc={posterImage} />
+        <S.InfoPoster src={posterImage} />
 
         <S.InfoTextBox>
           <ShowType type={getShowTypeText(genre)} />

--- a/src/pages/gig/components/peopleCard/PeopleCard.styled.ts
+++ b/src/pages/gig/components/peopleCard/PeopleCard.styled.ts
@@ -5,16 +5,13 @@ export const PeopleCardContainer = styled.article`
   flex-direction: column;
 `;
 
-export const PeopleCardPhoto = styled.img<{ $imgsrc: string }>`
+export const PeopleCardPhoto = styled.img`
   width: 15.7rem;
-  height: 14rem;
+  height: calc(15.7rem * 4 / 3);
   margin-bottom: 0.7rem;
   object-fit: cover;
   object-position: center;
 
-  background-image: url(${({ $imgsrc }) => $imgsrc});
-  background-position: center;
-  background-size: cover;
   border-radius: 6px;
 `;
 

--- a/src/pages/gig/components/peopleCard/PeopleCard.tsx
+++ b/src/pages/gig/components/peopleCard/PeopleCard.tsx
@@ -9,7 +9,7 @@ interface PeopleCardProps {
 const PeopleCard = ({ photo, role, name }: PeopleCardProps) => {
   return (
     <S.PeopleCardContainer>
-      <S.PeopleCardPhoto $imgsrc={photo} />
+      <S.PeopleCardPhoto src={photo} />
       <S.PeopleCardTextBox>
         <S.PeopleCardRole>{role}</S.PeopleCardRole>
         <S.PeopleCardName>{name}</S.PeopleCardName>

--- a/src/pages/gig/components/showInfo/ShowInfo.styled.ts
+++ b/src/pages/gig/components/showInfo/ShowInfo.styled.ts
@@ -5,13 +5,13 @@ export const ShowInfoWrapper = styled.section`
   ${Generators.flexGenerator("column", "center", "flex-start")};
 `;
 
-export const Poster = styled.img<{ $imgsrc: string }>`
+export const Poster = styled.img`
   width: 14.7rem;
   height: 19.8rem;
   margin: 1.2rem 0;
+  object-fit: cover;
+  object-position: center;
 
-  background-image: url(${({ $imgsrc }) => $imgsrc});
-  background-size: 100% 100%;
   border-radius: 4px;
 `;
 

--- a/src/pages/gig/components/showInfo/ShowInfo.tsx
+++ b/src/pages/gig/components/showInfo/ShowInfo.tsx
@@ -38,7 +38,7 @@ const ShowInfo = ({
 
   return (
     <S.ShowInfoWrapper>
-      <S.Poster $imgsrc={posterImage} />
+      <S.Poster src={posterImage} />
       <ShowType type={getShowTypeText(genre)} />
       <S.Title>{title}</S.Title>
       <div>

--- a/src/pages/main/components/performance/Performance.Cardstyled.ts
+++ b/src/pages/main/components/performance/Performance.Cardstyled.ts
@@ -15,6 +15,7 @@ export const PerformanceImg = styled.img`
   width: 15.7rem;
   height: 22.4rem;
 
+
   background-color: black;
   border-radius: 0.6rem;
 `;


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #333 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 비율 바꿨어요
2. img 태그 src 속성 사용했어요

## 📢 To Reviewers

- 딱히 없음

## 📸 스크린샷
<img width="158" alt="image" src="https://github.com/user-attachments/assets/e581b627-0bc6-4c03-9e3d-c03c9c1b4620">
<img width="142" alt="image" src="https://github.com/user-attachments/assets/01c8211f-7da0-45e2-90fc-282f168dd0bc">
img태그에서 background로 준거 풀어서 흰줄 사라졌어요
<img width="279" alt="image" src="https://github.com/user-attachments/assets/d0268fd1-9eb4-4733-a437-9774ad994e8a">
비율 바꿨어요

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
