### PR TITLE
[Fix/#335] 종료된 공연 예매 불가능 하도록 수정 및 로그인 여부에 따른 공연 등록 페이지 접근 로직 수정

### DIFF
--- a/src/pages/book/Book.tsx
+++ b/src/pages/book/Book.tsx
@@ -8,13 +8,13 @@ import {
   useGetScheduleAvailable,
 } from "@apis/domains/performances/queries";
 import { Button, Context, Loading, OuterLayout, ViewBottomSheet } from "@components/commons";
+import MetaTag from "@components/commons/meta/MetaTag";
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader, useLogin, useModal } from "@hooks";
 import { BookerInfo, Count, EasyPassEntry, Info, Select, TermCheck } from "@pages/book/components";
 import { SHOW_TYPE_KEY } from "@pages/gig/constants";
 import * as S from "./Book.styled";
 import { getScheduleNumberById } from "./utils";
-import MetaTag from "@components/commons/meta/MetaTag";
 
 const Book = () => {
   const navigate = useNavigate();
@@ -25,6 +25,24 @@ const Book = () => {
 
   const { isLogin } = useLogin();
   const { setHeader } = useHeader();
+
+  useEffect(() => {
+    if (data) {
+      const nowDate = new Date();
+      const lastPerformanceDate = new Date(
+        data.scheduleList[data?.scheduleList.length - 1].performanceDate
+      );
+      if (nowDate > lastPerformanceDate) {
+        openAlert({
+          title: "종료된 공연입니다.",
+          okText: "확인",
+          okCallback: () => {
+            navigate("/main");
+          },
+        });
+      }
+    }
+  }, [data]);
 
   useEffect(() => {
     setHeader({

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -1,6 +1,7 @@
 import { useGetPerformanceDetail } from "@apis/domains/performances/queries";
 import { ActionBottomSheet, Button, Loading } from "@components/commons";
 import OuterLayout from "@components/commons/bottomSheet/OuterLayout";
+import MetaTag from "@components/commons/meta/MetaTag";
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader, useLogin } from "@hooks";
 import { navigateAtom } from "@stores";
@@ -12,7 +13,6 @@ import Content from "./components/content/Content";
 import ShowInfo from "./components/showInfo/ShowInfo";
 import { SHOW_TYPE_KEY } from "./constants";
 import * as S from "./Gig.styled";
-import MetaTag from "@components/commons/meta/MetaTag";
 
 const Gig = () => {
   const navigate = useNavigate();
@@ -25,12 +25,18 @@ const Gig = () => {
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
+  const nowDate = new Date();
+  const lastPerformanceDate = new Date(
+    data?.scheduleList[data?.scheduleList.length - 1]?.performanceDate
+  );
+  // 현재 시간이 마지막 공연 시간보다 크면 예매 버튼 비활성화
+  const isBookDisabled = nowDate > lastPerformanceDate;
+
   const handleBookClick = () => {
     if (isLogin) {
       navigate(`/book/${performanceId}`);
       return;
     }
-
     setIsSheetOpen(true);
   };
 
@@ -86,7 +92,9 @@ const Gig = () => {
         staffList={data?.staffList ?? []}
       />
       <S.FooterContainer>
-        <Button onClick={handleBookClick}>예매하기</Button>
+        <Button onClick={handleBookClick} disabled={isBookDisabled}>
+          {isBookDisabled ? "종료된 공연은 예매할 수 없습니다." : "예매하기"}
+        </Button>
       </S.FooterContainer>
 
       <ActionBottomSheet

--- a/src/pages/main/components/floating/Floating.styled.ts
+++ b/src/pages/main/components/floating/Floating.styled.ts
@@ -1,5 +1,5 @@
+import { BtnFloating, Union } from "@assets/svgs";
 import styled, { keyframes } from "styled-components";
-import { Union, BtnFloating } from "@assets/svgs";
 
 const float = keyframes`
   0% {
@@ -13,15 +13,15 @@ const float = keyframes`
   }
 `;
 
-export const Layer = styled.section`
-  position: relative;
+export const Layer = styled.section<{ $width: number }>`
+  position: fixed;
+  bottom: 15rem;
+  left: ${({ $width }) => `${$width / 2 + 50}px`};
+  z-index: 25;
 `;
 
 export const FloatingWrapper = styled.section`
-  position: fixed;
-  right: 0.3rem;
-  bottom: 15rem;
-  z-index: 25;
+  position: absolute;
   display: flex;
   flex-direction: column;
 
@@ -29,8 +29,6 @@ export const FloatingWrapper = styled.section`
 `;
 
 export const FloatingContainer = styled.section`
-  position: absolute;
-  right: 2.4rem;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;

--- a/src/pages/main/components/floating/Floating.tsx
+++ b/src/pages/main/components/floating/Floating.tsx
@@ -1,20 +1,47 @@
+import { useLogin, useModal } from "@hooks";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as S from "./Floating.styled";
 
 const Floating = () => {
   const navigate = useNavigate();
+  const { isLogin } = useLogin();
+  const { openAlert } = useModal();
+
+  const handleRegister = () => {
+    if (isLogin) {
+      navigate("/gig-register");
+    } else {
+      openAlert({
+        title: "로그인이 필요한 서비스입니다.",
+        okText: "확인",
+        okCallback: () => {
+          navigate("/main");
+        },
+      });
+    }
+  };
+
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   return (
-    <S.Layer>
+    <S.Layer $width={width}>
       <S.FloatingWrapper>
         <S.FloatingContainer>
           <S.UnionIcon></S.UnionIcon>
           <S.UnionText>공연을 등록해보세요!</S.UnionText>
-          <S.FloatingBtnWrapper
-            onClick={() => {
-              navigate("/gig-register");
-            }}
-          >
+          <S.FloatingBtnWrapper onClick={handleRegister}>
             <S.FloatingBtn />
           </S.FloatingBtnWrapper>
         </S.FloatingContainer>

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import * as S from "./Performance.styled";
 
 import Spacing from "@components/commons/spacing/Spacing";
+import { useLogin, useModal } from "@hooks";
 import BannerImg from "../../../../assets/images/banner_basic.png";
 import PerformnaceCard from "./PerformnaceCard";
 
@@ -21,9 +22,18 @@ interface PerformanceComponentProps {
 
 const Performance = ({ genre, performanceList = [] }: PerformanceComponentProps) => {
   const navigate = useNavigate();
+  const { isLogin } = useLogin();
+  const { openAlert } = useModal();
 
   const handleNavigate = () => {
-    navigate("/gig-register");
+    if (isLogin) {
+      navigate("/gig-register");
+    } else {
+      openAlert({
+        title: "로그인이 필요한 서비스입니다.",
+        okText: "확인",
+      });
+    }
   };
 
   const filteredData =

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -8,6 +8,7 @@ import InputBank from "@components/commons/bank/InputBank";
 import Button from "@components/commons/button/Button";
 import TextArea from "@components/commons/input/textArea/TextArea";
 import TextField from "@components/commons/input/textField/TextField";
+import MetaTag from "@components/commons/meta/MetaTag";
 import Spacing from "@components/commons/spacing/Spacing";
 import Stepper from "@components/commons/stepper/Stepper";
 import TimePicker from "@components/commons/timepicker/TimePicker";
@@ -46,7 +47,6 @@ import {
   onMinusClick,
   onPlusClick,
 } from "./utils/handleEvent";
-import MetaTag from "@components/commons/meta/MetaTag";
 
 const Register = () => {
   const { isLogin } = useLogin();
@@ -55,19 +55,18 @@ const Register = () => {
 
   const user = localStorage?.getItem("user");
   const [, setNavigateUrl] = useAtom(navigateAtom);
+
   const handleKakaoLogin = (url: string) => {
     setNavigateUrl(url);
     requestKakaoLogin();
   };
-  useEffect(() => {
-    const userObj = JSON.parse(user);
 
-    if (userObj === null) {
+  useEffect(() => {
+    if (!isLogin) {
       openAlert({
         title: "로그인이 필요한 서비스입니다.",
         okCallback: () => navigate("/main"),
       });
-      handleKakaoLogin("/gig-register");
     }
   }, []);
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #335 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 종료된 공연은 상세페이지에 예매버튼 비활성화
- [x] 예매 페이지로 바로 접근 시, 리다이렉트 하도록 수정
- [x] 메인 페이지 플로팅 버튼 우측 하단 고정
- [x] 공연 등록 버튼 클릭이나 접근 시, 로그인 여부 확인 로직 수정

