### PR TITLE
[Fix/#343] 공연 삭제 로직 수정

### DIFF
--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
   TimePicker,
 } from "@components/commons";
-
+import MetaTag from "@components/commons/meta/MetaTag";
 import { NAVIGATION_STATE } from "@constants/navigationState";
 import { useHeader, useModal } from "@hooks";
 import Content from "@pages/gig/components/content/Content";
@@ -34,12 +34,11 @@ import { GENRE_LIST } from "./constants/genreList";
 import * as S from "./ModifyManage.styled";
 import { BANK_TYPE, Cast, DataProps, Schedule, Staff } from "./typings/gigInfo";
 import { isAllFieldsFilled } from "./utils/handleEvent";
-import MetaTag from "@components/commons/meta/MetaTag";
 
 const ModifyManage = () => {
-  const [ModifyManageStep, setModifyManageStep] = useState(1); // 등록 step 나누기
+  const [modifyManageStep, setModifyManageStep] = useState(1); // 등록 step 나누기
   const { openConfirm, closeConfirm, openAlert, closeAlert } = useModal();
-  // gigInfo 초기화
+
   const { performanceId } = useParams();
   const navigate = useNavigate();
 
@@ -85,6 +84,7 @@ const ModifyManage = () => {
       setPerformanceContact(data.performanceContact);
       setTicketPrice(data.ticketPrice);
       setTotalScheduleCount(data.totalScheduleCount);
+      setIsExist(data.isBookerExist);
       setScheduleList(
         data.scheduleList.map((item) => ({
           scheduleId: item.scheduleId ?? -1,
@@ -123,7 +123,6 @@ const ModifyManage = () => {
 
   const { mutateAsync: updatePerformance } = useUpdatePerformance();
 
-  //여기서 공연 수정하기 PUT 요청 보내야함
   const handleComplete = async () => {
     const filteredCastList = castList.filter(
       (cast) => cast.castName || cast.castRole || cast.castPhoto
@@ -183,14 +182,6 @@ const ModifyManage = () => {
     setIsChecked(e.target.checked);
   };
 
-  useEffect(() => {
-    setIsExist(data?.isBookerExist);
-  }, [data?.isBookerExist]);
-
-  // useEffect(() => {
-  //   setBankInfo(bankName);
-  // }, [bankName]);
-
   // 티켓 가격이 무료일 때 가격을 0으로 설정하고 수정 불가능하게 함
   useEffect(() => {
     if (isFree) {
@@ -214,7 +205,7 @@ const ModifyManage = () => {
   const { setHeader } = useHeader();
 
   const handleLeftBtn = () => {
-    if (ModifyManageStep === 1) {
+    if (modifyManageStep === 1) {
       openConfirm({
         title: "수정을 취소할까요?",
         subTitle: "페이지를 나갈 경우, 내용이 저장되지 않아요.",
@@ -244,13 +235,20 @@ const ModifyManage = () => {
     setTicketPrice(numericValue);
   };
 
-  const { mutate, mutateAsync } = usePerformanceDelete();
+  const { mutate, mutateAsync: deletePerformance } = usePerformanceDelete();
 
-  const handleDeletePerformance = async (_performanceId: number, isExisttt: boolean) => {
-    //사용자가 한명 이상 있으면 안된다는 문구 띄움 - 동훈이가 수정 시 공연 정보 조회 API (GET)에 COUNT나 bookingList를 넘겨줄 듯
-    console.log("isExisttt", isExisttt);
+  const handleDeletePerformance = async (_performanceId: number) => {
+    await deletePerformance(Number(performanceId));
 
-    if (isExisttt) {
+    openAlert({
+      title: "공연이 삭제되었습니다.",
+      okText: "확인했어요",
+      okCallback: () => navigate("/gig-manage"),
+    });
+  };
+
+  const handleRightBtn = () => {
+    if (isBookerExist) {
       openAlert({
         title: "공연 삭제가 불가해요.",
         subTitle: "예매자가 1명 이상 있을 경우, 삭제할 수 없어요.",
@@ -258,49 +256,36 @@ const ModifyManage = () => {
         okCallback: closeAlert,
       });
     } else {
-      //공연 삭제하는 로직 - performanceId 하나로 DELETE 요청 보내고,
-      mutateAsync(Number(performanceId));
-      navigate("/gig-manage");
+      openConfirm({
+        title: "공연을 삭제하시겠어요?",
+        subTitle: "삭제할 경우, 작성했던 내용을 되돌릴 수 없어요.",
+        okText: "삭제할게요",
+        okCallback: () => handleDeletePerformance(Number(performanceId)),
+        noText: "아니요",
+        noCallback: () => closeConfirm(),
+      });
     }
-  };
-
-  const handleRightBtn = () => {
-    openConfirm({
-      title: "공연을 삭제하시겠어요?",
-      subTitle: "삭제할 경우, 작성했던 내용을 되돌릴 수 없어요.",
-      okText: "삭제할게요",
-      okCallback: () => {
-        //공연 수정 DELETE API 요청 쏘는 로직 존재할 예정
-        handleDeletePerformance(Number(performanceId), isBookerExist as boolean); //예시로 박아둠
-      },
-      noText: "아니요",
-      noCallback: () => {
-        closeConfirm();
-      },
-    });
   };
 
   useEffect(() => {
     const pageTitle =
-      ModifyManageStep === 1
-        ? "공연 수정하기"
-        : ModifyManageStep === 2
-          ? "공연 수정하기"
-          : "미리보기";
+      modifyManageStep === 1 ? "공연 수정하기" : modifyManageStep === 2 ? "미리보기" : "";
+
     setHeader({
       headerStyle: NAVIGATION_STATE.ICON_TITLE_SUB_TEXT,
       title: pageTitle,
       subText: "삭제",
       leftOnClick: handleLeftBtn,
-      rightOnClick: handleRightBtn,
+      rightOnClick: () => handleRightBtn(),
     });
-  }, [setHeader, ModifyManageStep]);
+  }, [modifyManageStep, isBookerExist]);
+
   if (isLoading) {
     return <Loading />;
   }
 
   if (data) {
-    if (ModifyManageStep === 1) {
+    if (modifyManageStep === 1) {
       return (
         <>
           <MetaTag title="공연 수정" />
@@ -546,7 +531,7 @@ const ModifyManage = () => {
     //   );
     // }
 
-    if (ModifyManageStep === 2) {
+    if (modifyManageStep === 2) {
       return (
         <>
           <MetaTag title="공연 수정" />


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #343 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. alert의 okText를 누르면 검사하던 예매자 존재 여부를 헤더의 삭제 버튼 클릭시 검사하도록 변경 
2. useEffect의 인자로 isBookerExist 추가하여 예매자 존재 여부 함수 내부에서 받아오지 못하던 오류 수정

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/user-attachments/assets/24e5d74a-6588-4a64-813e-8c59551ba5c3

첫 번째는 예매자가 없는 경우 
두 번째는 예매자가 있는 경우 -> 삭제 불가능 alert