### PR TITLE
[Refactor/#362] 메인 및 예매 조회 UI 변경사항 반영

### DIFF
--- a/src/components/commons/button/Button.styled.ts
+++ b/src/components/commons/button/Button.styled.ts
@@ -27,37 +27,51 @@ const height = {
 export const DefaultBtn = styled.button<DefaultBtnPropTypes>`
   ${Generators.flexGenerator("row", "center", "center")};
   ${({ $size }) => {
-    switch ($size) {
-      case "xlarge":
-        return css`
-          ${({ theme }) => theme.fonts["body1-normal-semi"]};
-        `;
-      case "large":
-        return css`
-          ${({ theme }) => theme.fonts["body2-normal-semi"]};
-        `;
-      case "medium":
-        return css`
-          ${({ theme }) => theme.fonts["body2-normal-semi"]};
-        `;
-      case "small":
-        return css`
-          ${({ theme }) => theme.fonts["body2-normal-semi"]};
-        `;
-      case "xsmall":
-        return css`
-          ${({ theme }) => theme.fonts["caption1-semi"]};
-        `;
+    if (typeof $size === "string") {
+      switch ($size) {
+        case "xlarge":
+          return css`
+            width: 32.7rem;
+            height: 5.6rem;
+            ${({ theme }) => theme.fonts["body1-normal-semi"]};
+          `;
+        case "large":
+          return css`
+            width: 27.9rem;
+            height: 4.6rem;
+            ${({ theme }) => theme.fonts["body2-normal-semi"]};
+          `;
+        case "medium":
+          return css`
+            width: 15.8rem;
+            height: 4.6rem;
+            ${({ theme }) => theme.fonts["body2-normal-semi"]};
+          `;
+        case "small":
+          return css`
+            width: 13.6rem;
+            height: 4.6rem;
+            ${({ theme }) => theme.fonts["body2-normal-semi"]};
+          `;
+        case "xsmall":
+          return css`
+            width: 10.3rem;
+            height: 3.6rem;
+            ${({ theme }) => theme.fonts["caption1-semi"]};
+          `;
+        default:
+          return css;
+      }
+    } else if (typeof $size === "object") {
+      return css`
+        width: ${$size.width};
+        height: ${$size.height};
+        ${({ theme }) => theme.fonts["caption1-semi"]};
+      `;
     }
-  }};
+  }}
   cursor: ${({ $isDisabled }) => ($isDisabled ? "not-allowed" : "cursor")};
   border-radius: 6px;
-  ${({ $size }) =>
-    $size &&
-    css`
-      width: ${width[$size]};
-      height: ${height[$size]};
-    `};
 
   ${({ $variant, $isDisabled }) => {
     switch ($variant) {

--- a/src/components/commons/button/Button.styled.ts
+++ b/src/components/commons/button/Button.styled.ts
@@ -26,40 +26,24 @@ const height = {
 
 export const DefaultBtn = styled.button<DefaultBtnPropTypes>`
   ${Generators.flexGenerator("row", "center", "center")};
-  ${({ $size }) => {
+  ${({ $size, theme }) => {
     if (typeof $size === "string") {
+      let font;
       switch ($size) {
         case "xlarge":
-          return css`
-            width: 32.7rem;
-            height: 5.6rem;
-            ${({ theme }) => theme.fonts["body1-normal-semi"]};
-          `;
-        case "large":
-          return css`
-            width: 27.9rem;
-            height: 4.6rem;
-            ${({ theme }) => theme.fonts["body2-normal-semi"]};
-          `;
-        case "medium":
-          return css`
-            width: 15.8rem;
-            height: 4.6rem;
-            ${({ theme }) => theme.fonts["body2-normal-semi"]};
-          `;
-        case "small":
-          return css`
-            width: 13.6rem;
-            height: 4.6rem;
-            ${({ theme }) => theme.fonts["body2-normal-semi"]};
-          `;
+          font = theme.fonts["body1-normal-semi"];
+          break;
         case "xsmall":
-          return css`
-            width: 10.3rem;
-            height: 3.6rem;
-            ${({ theme }) => theme.fonts["caption1-semi"]};
-          `;
+          font = theme.fonts["caption1-semi"];
+          break;
+        default:
+          font = theme.fonts["body2-normal-semi"];
       }
+      return css`
+        ${font};
+        width: ${width[$size]};
+        height: ${height[$size]};
+      `;
     } else if (typeof $size === "object") {
       return css`
         width: ${$size.width};

--- a/src/components/commons/button/Button.styled.ts
+++ b/src/components/commons/button/Button.styled.ts
@@ -59,8 +59,6 @@ export const DefaultBtn = styled.button<DefaultBtnPropTypes>`
             height: 3.6rem;
             ${({ theme }) => theme.fonts["caption1-semi"]};
           `;
-        default:
-          return css;
       }
     } else if (typeof $size === "object") {
       return css`

--- a/src/components/commons/button/Button.tsx
+++ b/src/components/commons/button/Button.tsx
@@ -1,7 +1,13 @@
 import React, { ReactNode } from "react";
 import * as S from "./Button.styled";
 
-export type ButtonSizeTypes = "xlarge" | "large" | "medium" | "small" | "xsmall";
+export type ButtonSizeTypes =
+  | "xlarge"
+  | "large"
+  | "medium"
+  | "small"
+  | "xsmall"
+  | { width: string; height: string };
 export type ButtonVariantTypes = "primary" | "line" | "gray" | "blue";
 
 //React.ButtonHTMLAttributes는 버튼 속성에 집중하긴 했지만, 제네릭 타입이다.

--- a/src/pages/lookup/components/LookupCard.styled.ts
+++ b/src/pages/lookup/components/LookupCard.styled.ts
@@ -7,7 +7,7 @@ export const LookupCardWrapper = styled.section`
   gap: 1.2rem;
   width: 21.2rem;
   height: 18.8rem;
-  padding: 1rem 1.6rem;
+  padding: 1.1rem 1.6rem;
 
   background-color: ${({ theme }) => theme.colors.gray_800};
   border-radius: 0.6rem;

--- a/src/pages/lookup/components/LookupCard.styled.ts
+++ b/src/pages/lookup/components/LookupCard.styled.ts
@@ -4,10 +4,10 @@ import { IconArrowRight } from "@assets/svgs";
 export const LookupCardWrapper = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
-  width: 21.4rem;
-  height: 19.8rem;
-  padding: 1.4rem 2rem;
+  gap: 1.2rem;
+  width: 21.2rem;
+  height: 18.8rem;
+  padding: 1rem 1.6rem;
 
   background-color: ${({ theme }) => theme.colors.gray_800};
   border-radius: 0.6rem;
@@ -38,7 +38,7 @@ export const TitleArrowRightIcon = styled(IconArrowRight)`
   height: 1.8rem;
 
   path {
-    fill: ${({ theme }) => theme.colors.gray_400};
+    fill: ${({ theme }) => theme.colors.gray_0};
   }
 `;
 

--- a/src/pages/lookup/components/LookupCard.styled.ts
+++ b/src/pages/lookup/components/LookupCard.styled.ts
@@ -15,7 +15,7 @@ export const LookupCardWrapper = styled.section`
 
 export const LookupTitleWrapper = styled.button`
   display: flex;
-  width: 17.5rem;
+  width: 18rem;
 `;
 
 export const LookupTitle = styled.div`

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -41,14 +41,12 @@ const LookupCard = ({
 
   const handleModal = (bank: string, number: string) => {
     openModal({
-      // 가격은 내일 API 명세서 보고 맞추기
       children: (
         <BankAccount
           bankName={bank}
           number={number}
           accountName={accountHolder}
           accountNumber={accountNumber}
-          // api 추가되면 수정하기
           price={totalPaymentAmount}
         />
       ),
@@ -57,12 +55,10 @@ const LookupCard = ({
 
   return (
     <S.LookupCardWrapper>
-      {/* 제목 선택하면 해당 공연으로 넘어갈 수 있도록!! -> API 수정되면 반영하기*/}
       <S.LookupTitleWrapper type="button" onClick={() => navigate(`/gig/${performanceId}`)}>
         <S.LookupTitle>{performanceTitle}</S.LookupTitle>
         <S.TitleArrowRightIcon />
       </S.LookupTitleWrapper>
-      <S.BoxDivider />
       <S.ContextLayout>
         <S.Context>
           <S.SubTitle>예매일</S.SubTitle>

--- a/src/pages/lookup/components/LookupWrapper.styled.ts
+++ b/src/pages/lookup/components/LookupWrapper.styled.ts
@@ -9,7 +9,7 @@ export const LookupLayout = styled.section`
 // layout + contextBox => 얘를 map 돌리기
 export const LookupContainer = styled.section`
   display: flex;
-  gap: 0.8rem;
+  gap: 0.7rem;
   width: auto;
   padding: 0.8rem 2.4rem;
 `;
@@ -22,8 +22,10 @@ export const LookupCardLeft = styled.section`
 `;
 
 export const LookupImage = styled.img`
-  width: 10.5rem;
-  height: 15.4rem;
+  width: 10.8rem;
+  height: 14.4rem;
+  object-fit: cover;
+  object-position: center;
 
   border-radius: 0.6rem;
 `;

--- a/src/pages/lookup/components/LookupWrapper.tsx
+++ b/src/pages/lookup/components/LookupWrapper.tsx
@@ -13,7 +13,7 @@ const LookupWrapper = ({ handleBtn, ...item }: LookupProps) => {
         <S.LookupCardLeft>
           <S.LookupImage src={item.posterImage} />
           <Label dueDate={item.dueDate} />
-          <Button variant="line" size="xsmall" onClick={handleBtn}>
+          <Button variant="line" size={{ width: "10.8rem", height: "3.6rem" }} onClick={handleBtn}>
             취소하기
           </Button>
         </S.LookupCardLeft>

--- a/src/pages/lookup/components/LookupWrapper.tsx
+++ b/src/pages/lookup/components/LookupWrapper.tsx
@@ -13,9 +13,19 @@ const LookupWrapper = ({ handleBtn, ...item }: LookupProps) => {
         <S.LookupCardLeft>
           <S.LookupImage src={item.posterImage} />
           <Label dueDate={item.dueDate} />
-          <Button variant="line" size={{ width: "10.8rem", height: "3.6rem" }} onClick={handleBtn}>
-            취소하기
-          </Button>
+          {item.dueDate >= 0 ? (
+            <Button
+              variant="line"
+              size={{ width: "10.8rem", height: "3.6rem" }}
+              onClick={handleBtn}
+            >
+              취소하기
+            </Button>
+          ) : (
+            <Button variant="line" disabled={true} size={{ width: "10.8rem", height: "3.6rem" }}>
+              취소하기
+            </Button>
+          )}
         </S.LookupCardLeft>
         <LookupCard {...item}></LookupCard>
       </S.LookupContainer>

--- a/src/pages/main/components/performance/Performance.styled.ts
+++ b/src/pages/main/components/performance/Performance.styled.ts
@@ -9,7 +9,7 @@ export const PerformanceWrapper = styled.section`
 export const PerformanceLayout = styled.section`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 3.5rem 1.3rem;
+  gap: 3.2rem 1.3rem;
 `;
 
 export const BannerWrapper = styled.button`

--- a/src/pages/main/components/performance/Performance.styled.ts
+++ b/src/pages/main/components/performance/Performance.styled.ts
@@ -9,7 +9,7 @@ export const PerformanceWrapper = styled.section`
 export const PerformanceLayout = styled.section`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem 1.3rem;
+  gap: 3.5rem 1.3rem;
 `;
 
 export const BannerWrapper = styled.button`

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -49,7 +49,7 @@ const Performance = ({ genre, performanceList = [] }: PerformanceComponentProps)
           <PerformnaceCard key={item.performanceId} {...item} />
         ))}
       </S.PerformanceLayout>
-      <Spacing marginBottom="1.5" />
+      <Spacing marginBottom="3.5" />
       {genre === "ALL" ? (
         <S.BannerWrapper onClick={handleNavigate}>
           <S.Banner $image={BannerImg} />

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -49,7 +49,7 @@ const Performance = ({ genre, performanceList = [] }: PerformanceComponentProps)
           <PerformnaceCard key={item.performanceId} {...item} />
         ))}
       </S.PerformanceLayout>
-      <Spacing marginBottom="3.5" />
+      <Spacing marginBottom="3.2" />
       {genre === "ALL" ? (
         <S.BannerWrapper onClick={handleNavigate}>
           <S.Banner $image={BannerImg} />

--- a/src/pages/main/components/performance/PerformanceCard.styled.ts
+++ b/src/pages/main/components/performance/PerformanceCard.styled.ts
@@ -60,6 +60,8 @@ export const PerformancePeriod = styled.div`
 `;
 
 export const PerformancePrice = styled.div`
+  margin-top: 0.4rem;
+
   color: ${({ theme }) => theme.colors.white};
 
   ${({ theme }) => theme.fonts["body2-normal-semi"]};


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #362 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

- [x] main 화면 글자 패딩값 변경
- [x] poster 컴포넌트 사이즈 변경
- [x] 예매내역 조회 뷰 전반적인 사이즈 및 패딩값 변경
- [x] 버튼 컴포넌트 사이즈 조절 가능하게 수정

## 📢 To Reviewers

- 디자인 측에서 xsmall 버튼 width를 유동적으로 사용하고 싶다고 요청하셔서 `<Button variant="line" size={{ width: "10.8rem", height: "3.6rem" }} >` 처럼 size에 width와 height를 주면 xsmall 폰트에 맞춰 사이즈 변경할 수 있도록 수정하였습니다!
- 서버에서 상태에 취소 추가해 주면 issue 하나 더 파서 관련해서 수정하겠습니다~
- 현재 공연이 끝나면 취소 버튼 비활성화 처리해 두었는데, 취소 상태 추가할 때 취소의 경우에도 버튼 비활성화 할 수 있도록 하겠습니다!

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/9469672c-af0f-4056-99ae-cae748c64049)
![image](https://github.com/user-attachments/assets/20a56acd-18e4-4e41-bc6a-52da3fd85f95)
![image](https://github.com/user-attachments/assets/536a1ed8-16ef-484a-8f3e-8758a02fc4b3)


