### PR TITLE
[Feat/#370] 상세 페이지에서 상세 이미지 뷰 추가

### DIFF
--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -62,7 +62,7 @@ const Gig = () => {
     return <Loading />;
   }
 
-  if (!data) {
+  if (!isLoading && !data) {
     return <NotFound />;
   }
 
@@ -88,6 +88,7 @@ const Gig = () => {
       />
       <Content
         description={data?.performanceDescription ?? ""}
+        performanceImageList={data?.performanceImageList ?? []}
         attentionNote={data?.performanceAttentionNote ?? ""}
         contact={data?.performanceContact ?? ""}
         teamName={data?.performanceTeamName ?? ""}

--- a/src/pages/gig/components/content/Content.tsx
+++ b/src/pages/gig/components/content/Content.tsx
@@ -20,8 +20,14 @@ export type StaffListType = {
   staffPhoto?: string;
 };
 
+export interface PerformanceImageList {
+  performanceImageId?: number;
+  performanceImage?: string;
+}
+
 interface ContentProps {
   description: string;
+  performanceImageList: PerformanceImageList[];
   attentionNote: string;
   contact: string;
   teamName: string;
@@ -31,6 +37,7 @@ interface ContentProps {
 
 const Content = ({
   description,
+  performanceImageList,
   attentionNote,
   contact,
   teamName,
@@ -50,6 +57,7 @@ const Content = ({
         {activeTab === TAB_TYPE.PERFORMANCE && (
           <PerformanceIntroduce
             description={description}
+            performanceImageList={performanceImageList}
             attentionNote={attentionNote}
             contact={contact}
           />

--- a/src/pages/gig/components/detailImage/DetailImage.styled.ts
+++ b/src/pages/gig/components/detailImage/DetailImage.styled.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ImageWrapper = styled.div<{ $showAllImages: boolean; $toggleAvailable: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: ${({ $showAllImages, $toggleAvailable }) =>
+    $showAllImages ? "auto" : $toggleAvailable && "700px"};
+  overflow: ${({ $showAllImages }) =>
+    $showAllImages ? "visible" : "hidden"}; /* 이미지의 하단 부분을 잘라내도록 설정 */
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: auto;
+`;
+
+export const ShowMoreButton = styled.button`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  padding: 1.6rem 9.1rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts["body1-normal-semi"]};
+
+  background-color: ${({ theme }) => theme.colors.gray_900};
+  cursor: pointer;
+  border: 1px solid ${({ theme }) => theme.colors.gray_700};
+  border-radius: 6px;
+`;
+
+export const Overlay = styled.div`
+  position: absolute;
+  bottom: 6.3rem;
+
+  width: 100%;
+  height: 10rem;
+
+  background: linear-gradient(180deg, rgb(27 27 27 / 0%) 0%, #1b1b1b 100%);
+`;

--- a/src/pages/gig/components/detailImage/DetailImage.styled.ts
+++ b/src/pages/gig/components/detailImage/DetailImage.styled.ts
@@ -9,9 +9,9 @@ export const Wrapper = styled.div`
 export const ImageWrapper = styled.div<{ $showAllImages: boolean; $toggleAvailable: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1.6rem;
   height: ${({ $showAllImages, $toggleAvailable }) =>
-    $showAllImages ? "auto" : $toggleAvailable && "700px"};
+    $showAllImages ? "auto" : $toggleAvailable && "70rem"};
   overflow: ${({ $showAllImages }) =>
     $showAllImages ? "visible" : "hidden"}; /* 이미지의 하단 부분을 잘라내도록 설정 */
 `;
@@ -24,7 +24,7 @@ export const Image = styled.img`
 export const ShowMoreButton = styled.button`
   display: flex;
   justify-content: space-between;
-  margin-top: 8px;
+  margin-top: 0.8rem;
   padding: 1.6rem 9.1rem;
 
   color: ${({ theme }) => theme.colors.white};
@@ -33,7 +33,7 @@ export const ShowMoreButton = styled.button`
   background-color: ${({ theme }) => theme.colors.gray_900};
   cursor: pointer;
   border: 1px solid ${({ theme }) => theme.colors.gray_700};
-  border-radius: 6px;
+  border-radius: 0.6rem;
 `;
 
 export const Overlay = styled.div`

--- a/src/pages/gig/components/detailImage/DetailImage.tsx
+++ b/src/pages/gig/components/detailImage/DetailImage.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { IconArrowDown, IconArrowUp } from "@assets/svgs";
+import * as S from "./DetailImage.styled";
+
+const DetailImage = ({ performanceImageList }) => {
+  const toggleAvailable = performanceImageList?.length > 2;
+  const [showAllImages, setShowAllImages] = useState(false);
+
+  const handleDetailImageToggle = () => {
+    setShowAllImages((prev) => !prev);
+  };
+
+  if (!performanceImageList || performanceImageList.length === 0) {
+    return null;
+  }
+
+  return (
+    <S.Wrapper>
+      <S.ImageWrapper $showAllImages={showAllImages} $toggleAvailable={toggleAvailable}>
+        {performanceImageList.map((image) => (
+          <S.Image key={image.performanceImageId} src={image.performanceImage} />
+        ))}
+      </S.ImageWrapper>
+
+      {toggleAvailable && (
+        <>
+          {!showAllImages && <S.Overlay />}
+          <S.ShowMoreButton onClick={handleDetailImageToggle}>
+            {showAllImages ? (
+              <>
+                <span>상세 이미지 접기</span> <IconArrowUp width={"24px"} />
+              </>
+            ) : (
+              <>
+                <span>상세 이미지 더보기</span> <IconArrowDown width={"24px"} />
+              </>
+            )}
+          </S.ShowMoreButton>
+        </>
+      )}
+    </S.Wrapper>
+  );
+};
+
+export default DetailImage;

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.styled.ts
@@ -20,6 +20,7 @@ export const Title = styled.h1`
 
 export const Description = styled.pre`
   width: 32.7rem;
+
   ${({ theme }) => theme.fonts["body2-long"]};
   color: ${({ theme }) => theme.colors.white};
   white-space: pre-line;
@@ -57,12 +58,12 @@ export const Toggle = styled.span`
 `;
 
 export const Contact = styled.p`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   width: 100%;
   padding: 1.2rem 1.2rem 1.2rem 0;
   text-decoration-line: underline;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
 
   color: ${({ theme }) => theme.colors.white};
 

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
@@ -1,14 +1,19 @@
+import { useState } from "react";
+import { PerformanceImageList } from "../content/Content";
 import Contact from "./Contact";
 import * as S from "./PerformanceIntroduce.styled";
+import DetailImage from "../detailImage/DetailImage";
 
 interface PerformanceIntroduceProps {
   description: string;
+  performanceImageList: PerformanceImageList[];
   attentionNote: string;
   contact: string;
 }
 
 const PerformanceIntroduce = ({
   description,
+  performanceImageList,
   attentionNote,
   contact,
 }: PerformanceIntroduceProps) => {
@@ -18,6 +23,7 @@ const PerformanceIntroduce = ({
         <S.Title>공연소개</S.Title>
         <S.Description>{description}</S.Description>
       </S.Container>
+      <DetailImage performanceImageList={performanceImageList} />
       <S.Divider />
       <S.Container>
         <S.Title>유의사항</S.Title>

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -602,6 +602,7 @@ const Register = () => {
         <Content
           description={performanceDescription}
           attentionNote={performanceAttentionNote}
+          performanceImageList={performanceImageList}
           contact={performanceContact}
           teamName={performanceTeamName}
           castList={castList.map((cast, index) => ({

--- a/src/typings/api/schema/index.ts
+++ b/src/typings/api/schema/index.ts
@@ -4,1538 +4,1757 @@
  */
 
 export interface paths {
-    "/api/tickets": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * 예매자 입금여부 수정 및 웹발신 API
-         * @description 메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.
-         */
-        put: operations["updateTickets"];
-        post?: never;
-        /**
-         * 예매자 삭제 API
-         * @description 메이커가 자신의 공연에 대한 예매자의 정보를 삭제하는 DELETE API입니다.
-         */
-        delete: operations["deleteTickets"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/api/tickets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/performances": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * 공연 정보 수정 API
-         * @description 공연 정보를 수정하는 PUT API입니다.
-         */
-        put: operations["updatePerformance"];
-        /**
-         * 공연 생성 API
-         * @description 공연을 생성하는 POST API입니다.
-         */
-        post: operations["createPerformance"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    /**
+     * 예매자 입금여부 수정 및 웹발신 API
+     * @description 메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.
+     */
+    put: operations["updateTickets"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 예매자 취소 API
+     * @description 메이커가 자신의 공연에 대한 1명 이상의 예매자의 정보를 취소 상태로 변경하는 PATCH API입니다.
+     */
+    patch: operations["cancelTickets"];
+    trace?: never;
+  };
+  "/api/performances": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/users/sign-up": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 로그인/회원가입 API
-         * @description 로그인/회원가입하는 POST API입니다.
-         */
-        post: operations["signUp"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    /**
+     * 공연 정보 수정 API
+     * @description 공연 정보를 수정하는 PUT API입니다.
+     */
+    put: operations["updatePerformance"];
+    /**
+     * 공연 생성 API
+     * @description 공연을 생성하는 POST API입니다.
+     */
+    post: operations["createPerformance"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/users/sign-up": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/users/sign-out": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 로그아웃 API
-         * @description 로그아웃하는 POST API입니다.
-         */
-        post: operations["signOut"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 로그인/회원가입 API
+     * @description 로그인/회원가입하는 POST API입니다.
+     */
+    post: operations["signUp"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/users/sign-out": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/bookings/member": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 회원 예매 API
-         * @description 회원이 예매를 요청하는 POST API입니다.
-         */
-        post: operations["createMemberBooking"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 로그아웃 API
+     * @description 로그아웃하는 POST API입니다.
+     */
+    post: operations["signOut"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/bookings/member": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/bookings/guest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 비회원 예매 API
-         * @description 비회원이 예매를 요청하는 POST API입니다.
-         */
-        post: operations["createGuestBookings"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 회원 예매 API
+     * @description 회원이 예매를 요청하는 POST API입니다.
+     */
+    post: operations["createMemberBooking"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/bookings/guest": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/bookings/guest/retrieve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 비회원 예매 조회 API
-         * @description 비회원이 예매를 조회하는 POST API입니다.
-         */
-        post: operations["getGuestBookings"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 비회원 예매 API
+     * @description 비회원이 예매를 요청하는 POST API입니다.
+     */
+    post: operations["createGuestBookings"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/bookings/guest/retrieve": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/health-check": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["healthcheck"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 비회원 예매 조회 API
+     * @description 비회원이 예매를 조회하는 POST API입니다.
+     */
+    post: operations["getGuestBookings"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/health-check": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/users/refresh-token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * access token 재발급 API
-         * @description refresh token으로 access token을 재발급하는 GET API입니다.
-         */
-        get: operations["refreshToken"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations["healthcheck"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/users/refresh-token": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/tickets/{performanceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 예매자 목록 조회 API
-         * @description 메이커가 자신의 공연에 대한 예매자 목록을 조회하는 GET API입니다.
-         */
-        get: operations["getTickets"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * access token 재발급 API
+     * @description refresh token으로 access token을 재발급하는 GET API입니다.
+     */
+    get: operations["refreshToken"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/tickets/{performanceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/schedules/{scheduleId}/availability": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getTicketAvailability"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 예매자 목록 조회 API
+     * @description 메이커가 자신의 공연에 대한 예매자 목록을 조회하는 GET API입니다.
+     */
+    get: operations["getTickets"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/schedules/{scheduleId}/availability": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/performances/{performanceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 공연 수정 페이지 정보 조회 API
-         * @description 공연 정보를 조회하는 GET API입니다.
-         */
-        get: operations["getPerformanceForEdit"];
-        put?: never;
-        post?: never;
-        /**
-         * 공연 삭제 API
-         * @description 공연을 삭제하는 DELETE API입니다.
-         */
-        delete: operations["deletePerformance"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations["getTicketAvailability"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances/{performanceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/performances/user": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 회원이 등록한 공연 목록 조회 API
-         * @description 회원이 등록한 공연 목록을 조회하는 GET API입니다.
-         */
-        get: operations["getUserPerformances"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 공연 수정 페이지 정보 조회 API
+     * @description 공연 정보를 조회하는 GET API입니다.
+     */
+    get: operations["getPerformanceForEdit"];
+    put?: never;
+    post?: never;
+    /**
+     * 공연 삭제 API
+     * @description 공연을 삭제하는 DELETE API입니다.
+     */
+    delete: operations["deletePerformance"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances/user": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/performances/detail/{performanceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 공연 상세정보 조회 API
-         * @description 공연 상세페이지의 공연 상세정보를 조회하는 GET API입니다.
-         */
-        get: operations["getPerformanceDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 회원이 등록한 공연 목록 조회 API
+     * @description 회원이 등록한 공연 목록을 조회하는 GET API입니다.
+     */
+    get: operations["getUserPerformances"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances/detail/{performanceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/performances/booking/{performanceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 예매하기 관련 공연 정보 조회 API
-         * @description 예매하기 페이지에서 필요한 예매 관련 공연 정보를 조회하는 GET API입니다.
-         */
-        get: operations["getBookingPerformanceDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 공연 상세정보 조회 API
+     * @description 공연 상세페이지의 공연 상세정보를 조회하는 GET API입니다.
+     */
+    get: operations["getPerformanceDetail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/performances/booking/{performanceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/main": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체공연목록, 홍보목록 조회 API
-         * @description 홈화면에서 전체공연목록, 홍보목록을 조회하는 GET API입니다.
-         */
-        get: operations["getHomePerformanceList"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 예매하기 관련 공연 정보 조회 API
+     * @description 예매하기 페이지에서 필요한 예매 관련 공연 정보를 조회하는 GET API입니다.
+     */
+    get: operations["getBookingPerformanceDetail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/main": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/files/presigned-url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * presigned-url API
-         * @description S3에 업로드 할 수 있는 유효한 url을 주는 GET API입니다.
-         */
-        get: operations["getPresignedUrls"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체공연목록, 홍보목록 조회 API
+     * @description 홈화면에서 전체공연목록, 홍보목록을 조회하는 GET API입니다.
+     */
+    get: operations["getHomePerformanceList"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/presigned-url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/bookings/member/retrieve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 회원 예매 조회 API
-         * @description 회원이 예매를 조회하는 GET API입니다.
-         */
-        get: operations["getMemberBookings"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * presigned-url API
+     * @description S3에 업로드 할 수 있는 유효한 url을 주는 GET API입니다.
+     */
+    get: operations["getPresignedUrls"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/bookings/member/retrieve": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    /**
+     * 회원 예매 조회 API
+     * @description 회원이 예매를 조회하는 GET API입니다.
+     */
+    get: operations["getMemberBookings"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        TicketUpdateDetail: {
-            /** Format: int64 */
-            bookingId?: number;
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** Format: date-time */
-            createdAt?: string;
-            isPaymentCompleted?: boolean;
-            scheduleNumber?: string;
-        };
-        TicketUpdateRequest: {
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            bookingList?: components["schemas"]["TicketUpdateDetail"][];
-        };
-        SuccessResponseVoid: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: Record<string, never>;
-        };
-        CastUpdateRequest: {
-            /** Format: int64 */
-            castId?: number;
-            castName?: string;
-            castRole?: string;
-            castPhoto?: string;
-        };
-        PerformanceUpdateRequest: {
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** @enum {string} */
-            genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
-            /** Format: int32 */
-            runningTime?: number;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            posterImage?: string;
-            performanceTeamName?: string;
-            performanceVenue?: string;
-            performanceContact?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            scheduleList?: components["schemas"]["ScheduleUpdateRequest"][];
-            castList?: components["schemas"]["CastUpdateRequest"][];
-            staffList?: components["schemas"]["StaffUpdateRequest"][];
-        };
-        ScheduleUpdateRequest: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: date-time */
-            performanceDate?: string;
-            /** Format: int32 */
-            totalTicketCount?: number;
-            scheduleNumber?: string;
-        };
-        StaffUpdateRequest: {
-            /** Format: int64 */
-            staffId?: number;
-            staffName?: string;
-            staffRole?: string;
-            staffPhoto?: string;
-        };
-        CastUpdateResponse: {
-            /** Format: int64 */
-            castId?: number;
-            castName?: string;
-            castRole?: string;
-            castPhoto?: string;
-        };
-        PerformanceUpdateResponse: {
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** @enum {string} */
-            genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
-            /** Format: int32 */
-            runningTime?: number;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            posterImage?: string;
-            performanceTeamName?: string;
-            performanceVenue?: string;
-            performanceContact?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            ticketPrice?: number;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            scheduleList?: components["schemas"]["ScheduleUpdateResponse"][];
-            castList?: components["schemas"]["CastUpdateResponse"][];
-            staffList?: components["schemas"]["StaffUpdateResponse"][];
-        };
-        ScheduleUpdateResponse: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: date-time */
-            performanceDate?: string;
-            /** Format: int32 */
-            totalTicketCount?: number;
-            /** Format: int32 */
-            dueDate?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-        };
-        StaffUpdateResponse: {
-            /** Format: int64 */
-            staffId?: number;
-            staffName?: string;
-            staffRole?: string;
-            staffPhoto?: string;
-        };
-        SuccessResponsePerformanceUpdateResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["PerformanceUpdateResponse"];
-        };
-        MemberLoginRequest: {
-            /** @enum {string} */
-            socialType: "KAKAO";
-        };
-        LoginSuccessResponse: {
-            accessToken?: string;
-            refreshToken?: string;
-            nickname?: string;
-        };
-        SuccessResponseLoginSuccessResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["LoginSuccessResponse"];
-        };
-        CastRequest: {
-            castName?: string;
-            castRole?: string;
-            castPhoto?: string;
-        };
-        PerformanceRequest: {
-            performanceTitle?: string;
-            /** @enum {string} */
-            genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
-            /** Format: int32 */
-            runningTime?: number;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            posterImage?: string;
-            performanceTeamName?: string;
-            performanceVenue?: string;
-            performanceContact?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            ticketPrice?: number;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            scheduleList?: components["schemas"]["ScheduleRequest"][];
-            castList?: components["schemas"]["CastRequest"][];
-            staffList?: components["schemas"]["StaffRequest"][];
-        };
-        ScheduleRequest: {
-            /** Format: date-time */
-            performanceDate?: string;
-            /** Format: int32 */
-            totalTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-        };
-        StaffRequest: {
-            staffName?: string;
-            staffRole?: string;
-            staffPhoto?: string;
-        };
-        CastResponse: {
-            /** Format: int64 */
-            castId?: number;
-            castName?: string;
-            castRole?: string;
-            castPhoto?: string;
-        };
-        PerformanceResponse: {
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** @enum {string} */
-            genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
-            /** Format: int32 */
-            runningTime?: number;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            posterImage?: string;
-            performanceTeamName?: string;
-            performanceVenue?: string;
-            performanceContact?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            ticketPrice?: number;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            scheduleList?: components["schemas"]["ScheduleResponse"][];
-            castList?: components["schemas"]["CastResponse"][];
-            staffList?: components["schemas"]["StaffResponse"][];
-        };
-        ScheduleResponse: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: date-time */
-            performanceDate?: string;
-            /** Format: int32 */
-            totalTicketCount?: number;
-            /** Format: int32 */
-            dueDate?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-        };
-        StaffResponse: {
-            /** Format: int64 */
-            staffId?: number;
-            staffName?: string;
-            staffRole?: string;
-            staffPhoto?: string;
-        };
-        SuccessResponsePerformanceResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["PerformanceResponse"];
-        };
-        MemberBookingRequest: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            isPaymentCompleted?: boolean;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-        };
-        MemberBookingResponse: {
-            /** Format: int64 */
-            bookingId?: number;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            isPaymentCompleted?: boolean;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-            /** Format: date-time */
-            createdAt?: string;
-        };
-        SuccessResponseMemberBookingResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["MemberBookingResponse"];
-        };
-        GuestBookingRequest: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            birthDate?: string;
-            password?: string;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-            isPaymentCompleted?: boolean;
-        };
-        GuestBookingResponse: {
-            /** Format: int64 */
-            bookingId?: number;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            isPaymentCompleted?: boolean;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-            /** Format: date-time */
-            createdAt?: string;
-        };
-        SuccessResponseGuestBookingResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["GuestBookingResponse"];
-        };
-        GuestBookingRetrieveRequest: {
-            bookerName?: string;
-            birthDate?: string;
-            bookerPhoneNumber?: string;
-            password?: string;
-        };
-        GuestBookingRetrieveResponse: {
-            /** Format: int64 */
-            bookingId?: number;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** Format: date-time */
-            performanceDate?: string;
-            performanceVenue?: string;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            bookerName?: string;
-            performanceContact?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            /** Format: int32 */
-            dueDate?: number;
-            isPaymentCompleted?: boolean;
-            /** Format: date-time */
-            createdAt?: string;
-            posterImage?: string;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-        };
-        SuccessResponseListGuestBookingRetrieveResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["GuestBookingRetrieveResponse"][];
-        };
-        AccessTokenGetSuccess: {
-            accessToken?: string;
-        };
-        SuccessResponseAccessTokenGetSuccess: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["AccessTokenGetSuccess"];
-        };
-        SuccessResponseTicketRetrieveResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["TicketRetrieveResponse"];
-        };
-        TicketDetail: {
-            /** Format: int64 */
-            bookingId?: number;
-            bookerName?: string;
-            bookerPhoneNumber?: string;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** Format: date-time */
-            createdAt?: string;
-            isPaymentCompleted?: boolean;
-            scheduleNumber?: string;
-        };
-        TicketRetrieveResponse: {
-            performanceTitle?: string;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            bookingList?: components["schemas"]["TicketDetail"][];
-        };
-        SuccessResponseTicketAvailabilityResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["TicketAvailabilityResponse"];
-        };
-        TicketAvailabilityResponse: {
-            /** Format: int64 */
-            scheduleId?: number;
-            scheduleNumber?: string;
-            /** Format: int32 */
-            totalTicketCount?: number;
-            /** Format: int32 */
-            soldTicketCount?: number;
-            /** Format: int32 */
-            availableTicketCount?: number;
-            /** Format: int32 */
-            requestedTicketCount?: number;
-            isAvailable?: boolean;
-        };
-        PerformanceEditResponse: {
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** @enum {string} */
-            genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
-            /** Format: int32 */
-            runningTime?: number;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            posterImage?: string;
-            performanceTeamName?: string;
-            performanceVenue?: string;
-            performanceContact?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            ticketPrice?: number;
-            /** Format: int32 */
-            totalScheduleCount?: number;
-            isBookerExist?: boolean;
-            scheduleList?: components["schemas"]["ScheduleResponse"][];
-            castList?: components["schemas"]["CastResponse"][];
-            staffList?: components["schemas"]["StaffResponse"][];
-        };
-        SuccessResponsePerformanceEditResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["PerformanceEditResponse"];
-        };
-        MakerPerformanceDetail: {
-            /** Format: int64 */
-            performanceId?: number;
-            genre?: string;
-            performanceTitle?: string;
-            posterImage?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            minDueDate?: number;
-        };
-        MakerPerformanceResponse: {
-            /** Format: int64 */
-            userId?: number;
-            performances?: components["schemas"]["MakerPerformanceDetail"][];
-        };
-        SuccessResponseMakerPerformanceResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["MakerPerformanceResponse"];
-        };
-        PerformanceDetailCast: {
-            /** Format: int64 */
-            castId?: number;
-            castName?: string;
-            castRole?: string;
-            castPhoto?: string;
-        };
-        PerformanceDetailResponse: {
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            performancePeriod?: string;
-            scheduleList?: components["schemas"]["PerformanceDetailSchedule"][];
-            /** Format: int32 */
-            ticketPrice?: number;
-            genre?: string;
-            posterImage?: string;
-            /** Format: int32 */
-            runningTime?: number;
-            performanceVenue?: string;
-            performanceDescription?: string;
-            performanceAttentionNote?: string;
-            performanceContact?: string;
-            performanceTeamName?: string;
-            castList?: components["schemas"]["PerformanceDetailCast"][];
-            staffList?: components["schemas"]["PerformanceDetailStaff"][];
-            /** Format: int32 */
-            minDueDate?: number;
-        };
-        PerformanceDetailSchedule: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: date-time */
-            performanceDate?: string;
-            scheduleNumber?: string;
-            /** Format: int32 */
-            dueDate?: number;
-            isBooking?: boolean;
-        };
-        PerformanceDetailStaff: {
-            /** Format: int64 */
-            staffId?: number;
-            staffName?: string;
-            staffRole?: string;
-            staffPhoto?: string;
-        };
-        SuccessResponsePerformanceDetailResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["PerformanceDetailResponse"];
-        };
-        BookingPerformanceDetailResponse: {
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            performancePeriod?: string;
-            scheduleList?: components["schemas"]["BookingPerformanceDetailSchedule"][];
-            /** Format: int32 */
-            ticketPrice?: number;
-            genre?: string;
-            posterImage?: string;
-            performanceVenue?: string;
-            performanceTeamName?: string;
-            bankName?: string;
-            accountNumber?: string;
-            accountHolder?: string;
-        };
-        BookingPerformanceDetailSchedule: {
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: date-time */
-            performanceDate?: string;
-            scheduleNumber?: string;
-            /** Format: int32 */
-            availableTicketCount?: number;
-            isBooking?: boolean;
-            /** Format: int32 */
-            dueDate?: number;
-        };
-        SuccessResponseBookingPerformanceDetailResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["BookingPerformanceDetailResponse"];
-        };
-        HomePerformanceDetail: {
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            performancePeriod?: string;
-            /** Format: int32 */
-            ticketPrice?: number;
-            /** Format: int32 */
-            dueDate?: number;
-            genre?: string;
-            posterImage?: string;
-            performanceVenue?: string;
-        };
-        HomePromotionDetail: {
-            /** Format: int64 */
-            promotionId?: number;
-            promotionPhoto?: string;
-            /** Format: int64 */
-            performanceId?: number;
-            redirectUrl?: string;
-            isExternal?: boolean;
-        };
-        HomeResponse: {
-            promotionList?: components["schemas"]["HomePromotionDetail"][];
-            performanceList?: components["schemas"]["HomePerformanceDetail"][];
-        };
-        SuccessResponseHomeResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["HomeResponse"];
-        };
-        MemberBookingRetrieveResponse: {
-            /** Format: int64 */
-            userId?: number;
-            /** Format: int64 */
-            bookingId?: number;
-            /** Format: int64 */
-            scheduleId?: number;
-            /** Format: int64 */
-            performanceId?: number;
-            performanceTitle?: string;
-            /** Format: date-time */
-            performanceDate?: string;
-            performanceVenue?: string;
-            /** Format: int32 */
-            purchaseTicketCount?: number;
-            /** @enum {string} */
-            scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-            bookerName?: string;
-            performanceContact?: string;
-            /** @enum {string} */
-            bankName?: "NH_NONGHYUP" | "KAKAOBANK" | "KB_KOOKMIN" | "TOSSBANK" | "SHINHAN" | "WOORI" | "IBK_GIUP" | "HANA" | "SAEMAUL" | "BUSAN" | "IMBANK_DAEGU" | "SINHYEOP" | "WOOCHAEGUK" | "SCJEIL" | "SUHYEOP" | "NONE";
-            accountNumber?: string;
-            accountHolder?: string;
-            /** Format: int32 */
-            dueDate?: number;
-            isPaymentCompleted?: boolean;
-            /** Format: date-time */
-            createdAt?: string;
-            posterImage?: string;
-            /** Format: int32 */
-            totalPaymentAmount?: number;
-        };
-        SuccessResponseMemberBookingRetrieveResponse: {
-            /** Format: int32 */
-            status?: number;
-            message?: string;
-            data?: components["schemas"]["MemberBookingRetrieveResponse"];
-        };
-        TicketDeleteRequest: {
-            /** Format: int64 */
-            performanceId?: number;
-            bookingList?: number[];
-        };
+  schemas: {
+    TicketUpdateDetail: {
+      /** Format: int64 */
+      bookingId?: number;
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      scheduleNumber?: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    TicketUpdateRequest: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      bookingList?: components["schemas"]["TicketUpdateDetail"][];
+    };
+    SuccessResponseVoid: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: Record<string, never>;
+    };
+    CastModifyRequest: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceImageModifyRequest: {
+      /** Format: int64 */
+      performanceImageId?: number;
+      performanceImage?: string;
+    };
+    PerformanceModifyRequest: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      /** Format: int32 */
+      ticketPrice?: number;
+      scheduleModifyRequests?: components["schemas"]["ScheduleModifyRequest"][];
+      castModifyRequests?: components["schemas"]["CastModifyRequest"][];
+      staffModifyRequests?: components["schemas"]["StaffModifyRequest"][];
+      performanceImageModifyRequests?: components["schemas"]["PerformanceImageModifyRequest"][];
+    };
+    ScheduleModifyRequest: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+    };
+    StaffModifyRequest: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    CastModifyResponse: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceImageModifyResponse: {
+      /** Format: int64 */
+      performanceImageId?: number;
+      performanceImage?: string;
+    };
+    PerformanceModifyResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleModifyResponses?: components["schemas"]["ScheduleModifyResponse"][];
+      castModifyResponses?: components["schemas"]["CastModifyResponse"][];
+      staffModifyResponses?: components["schemas"]["StaffModifyResponse"][];
+      performanceImageModifyResponses?: components["schemas"]["PerformanceImageModifyResponse"][];
+    };
+    ScheduleModifyResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffModifyResponse: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    SuccessResponsePerformanceModifyResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceModifyResponse"];
+    };
+    MemberLoginRequest: {
+      /** @enum {string} */
+      socialType: "KAKAO";
+    };
+    LoginSuccessResponse: {
+      accessToken?: string;
+      refreshToken?: string;
+      nickname?: string;
+    };
+    SuccessResponseLoginSuccessResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["LoginSuccessResponse"];
+    };
+    CastRequest: {
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceImageRequest: {
+      performanceImage?: string;
+    };
+    PerformanceRequest: {
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleRequest"][];
+      castList?: components["schemas"]["CastRequest"][];
+      staffList?: components["schemas"]["StaffRequest"][];
+      performanceImageList?: components["schemas"]["PerformanceImageRequest"][];
+    };
+    ScheduleRequest: {
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffRequest: {
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    CastResponse: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceImageResponse: {
+      /** Format: int64 */
+      imageId?: number;
+      imageUrl?: string;
+    };
+    PerformanceResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      scheduleList?: components["schemas"]["ScheduleResponse"][];
+      castList?: components["schemas"]["CastResponse"][];
+      staffList?: components["schemas"]["StaffResponse"][];
+      performanceImageList?: components["schemas"]["PerformanceImageResponse"][];
+    };
+    ScheduleResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+    };
+    StaffResponse: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    SuccessResponsePerformanceResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceResponse"];
+    };
+    MemberBookingRequest: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+    };
+    MemberBookingResponse: {
+      /** Format: int64 */
+      bookingId?: number;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+    };
+    SuccessResponseMemberBookingResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["MemberBookingResponse"];
+    };
+    GuestBookingRequest: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      birthDate?: string;
+      password?: string;
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+    };
+    GuestBookingResponse: {
+      /** Format: int64 */
+      bookingId?: number;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+    };
+    SuccessResponseGuestBookingResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["GuestBookingResponse"];
+    };
+    GuestBookingRetrieveRequest: {
+      bookerName?: string;
+      birthDate?: string;
+      bookerPhoneNumber?: string;
+      password?: string;
+    };
+    GuestBookingRetrieveResponse: {
+      /** Format: int64 */
+      bookingId?: number;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** Format: date-time */
+      performanceDate?: string;
+      performanceVenue?: string;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      bookerName?: string;
+      performanceContact?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      /** Format: date-time */
+      createdAt?: string;
+      posterImage?: string;
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+    };
+    SuccessResponseListGuestBookingRetrieveResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["GuestBookingRetrieveResponse"][];
+    };
+    TicketCancelRequest: {
+      /** Format: int64 */
+      performanceId?: number;
+      bookingList?: number[];
+    };
+    AccessTokenGetSuccess: {
+      accessToken?: string;
+    };
+    SuccessResponseAccessTokenGetSuccess: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["AccessTokenGetSuccess"];
+    };
+    SuccessResponseTicketRetrieveResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["TicketRetrieveResponse"];
+    };
+    TicketDetail: {
+      /** Format: int64 */
+      bookingId?: number;
+      bookerName?: string;
+      bookerPhoneNumber?: string;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      scheduleNumber?: string;
+    };
+    TicketRetrieveResponse: {
+      performanceTitle?: string;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      bookingList?: components["schemas"]["TicketDetail"][];
+    };
+    SuccessResponseTicketAvailabilityResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["TicketAvailabilityResponse"];
+    };
+    TicketAvailabilityResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      scheduleNumber?: string;
+      /** Format: int32 */
+      totalTicketCount?: number;
+      /** Format: int32 */
+      soldTicketCount?: number;
+      /** Format: int32 */
+      availableTicketCount?: number;
+      /** Format: int32 */
+      requestedTicketCount?: number;
+      isAvailable?: boolean;
+    };
+    PerformanceModifyDetailResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** @enum {string} */
+      genre?: "BAND" | "PLAY" | "DANCE" | "ETC";
+      /** Format: int32 */
+      runningTime?: number;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      posterImage?: string;
+      performanceTeamName?: string;
+      performanceVenue?: string;
+      performanceContact?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      totalScheduleCount?: number;
+      isBookerExist?: boolean;
+      scheduleList?: components["schemas"]["ScheduleResponse"][];
+      castList?: components["schemas"]["CastResponse"][];
+      staffList?: components["schemas"]["StaffResponse"][];
+      performanceImageList?: components["schemas"]["PerformanceImageResponse"][];
+    };
+    SuccessResponsePerformanceModifyDetailResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceModifyDetailResponse"];
+    };
+    MakerPerformanceDetailResponse: {
+      /** Format: int64 */
+      performanceId?: number;
+      genre?: string;
+      performanceTitle?: string;
+      posterImage?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      minDueDate?: number;
+    };
+    MakerPerformanceResponse: {
+      /** Format: int64 */
+      userId?: number;
+      performances?: components["schemas"]["MakerPerformanceDetailResponse"][];
+    };
+    SuccessResponseMakerPerformanceResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["MakerPerformanceResponse"];
+    };
+    PerformanceDetailCastResponse: {
+      /** Format: int64 */
+      castId?: number;
+      castName?: string;
+      castRole?: string;
+      castPhoto?: string;
+    };
+    PerformanceDetailImageResponse: {
+      /** Format: int64 */
+      performanceImageId?: number;
+      performanceImage?: string;
+    };
+    PerformanceDetailResponse: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      performancePeriod?: string;
+      scheduleList?: components["schemas"]["PerformanceDetailScheduleResponse"][];
+      /** Format: int32 */
+      ticketPrice?: number;
+      genre?: string;
+      posterImage?: string;
+      /** Format: int32 */
+      runningTime?: number;
+      performanceVenue?: string;
+      performanceDescription?: string;
+      performanceAttentionNote?: string;
+      performanceContact?: string;
+      performanceTeamName?: string;
+      castList?: components["schemas"]["PerformanceDetailCastResponse"][];
+      staffList?: components["schemas"]["PerformanceDetailStaffResponse"][];
+      /** Format: int32 */
+      minDueDate?: number;
+      performanceImageList?: components["schemas"]["PerformanceDetailImageResponse"][];
+    };
+    PerformanceDetailScheduleResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      scheduleNumber?: string;
+      /** Format: int32 */
+      dueDate?: number;
+      isBooking?: boolean;
+    };
+    PerformanceDetailStaffResponse: {
+      /** Format: int64 */
+      staffId?: number;
+      staffName?: string;
+      staffRole?: string;
+      staffPhoto?: string;
+    };
+    SuccessResponsePerformanceDetailResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["PerformanceDetailResponse"];
+    };
+    BookingPerformanceDetailResponse: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      performancePeriod?: string;
+      scheduleList?: components["schemas"]["BookingPerformanceDetailScheduleResponse"][];
+      /** Format: int32 */
+      ticketPrice?: number;
+      genre?: string;
+      posterImage?: string;
+      performanceVenue?: string;
+      performanceTeamName?: string;
+      bankName?: string;
+      accountNumber?: string;
+      accountHolder?: string;
+    };
+    BookingPerformanceDetailScheduleResponse: {
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: date-time */
+      performanceDate?: string;
+      scheduleNumber?: string;
+      /** Format: int32 */
+      availableTicketCount?: number;
+      isBooking?: boolean;
+      /** Format: int32 */
+      dueDate?: number;
+    };
+    SuccessResponseBookingPerformanceDetailResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["BookingPerformanceDetailResponse"];
+    };
+    HomePerformanceDetail: {
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      performancePeriod?: string;
+      /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
+      dueDate?: number;
+      genre?: string;
+      posterImage?: string;
+      performanceVenue?: string;
+    };
+    HomePromotionDetail: {
+      /** Format: int64 */
+      promotionId?: number;
+      promotionPhoto?: string;
+      /** Format: int64 */
+      performanceId?: number;
+      redirectUrl?: string;
+      isExternal?: boolean;
+    };
+    HomeResponse: {
+      promotionList?: components["schemas"]["HomePromotionDetail"][];
+      performanceList?: components["schemas"]["HomePerformanceDetail"][];
+    };
+    SuccessResponseHomeResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["HomeResponse"];
+    };
+    MemberBookingRetrieveResponse: {
+      /** Format: int64 */
+      userId?: number;
+      /** Format: int64 */
+      bookingId?: number;
+      /** Format: int64 */
+      scheduleId?: number;
+      /** Format: int64 */
+      performanceId?: number;
+      performanceTitle?: string;
+      /** Format: date-time */
+      performanceDate?: string;
+      performanceVenue?: string;
+      /** Format: int32 */
+      purchaseTicketCount?: number;
+      /** @enum {string} */
+      scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+      bookerName?: string;
+      performanceContact?: string;
+      /** @enum {string} */
+      bankName?:
+        | "NH_NONGHYUP"
+        | "KAKAOBANK"
+        | "KB_KOOKMIN"
+        | "TOSSBANK"
+        | "SHINHAN"
+        | "WOORI"
+        | "IBK_GIUP"
+        | "HANA"
+        | "SAEMAUL"
+        | "BUSAN"
+        | "IMBANK_DAEGU"
+        | "SINHYEOP"
+        | "WOOCHAEGUK"
+        | "SCJEIL"
+        | "SUHYEOP"
+        | "NONE";
+      accountNumber?: string;
+      accountHolder?: string;
+      /** Format: int32 */
+      dueDate?: number;
+      /** @enum {string} */
+      bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      /** Format: date-time */
+      createdAt?: string;
+      posterImage?: string;
+      /** Format: int32 */
+      totalPaymentAmount?: number;
+    };
+    SuccessResponseMemberBookingRetrieveResponse: {
+      /** Format: int32 */
+      status?: number;
+      message?: string;
+      data?: components["schemas"]["MemberBookingRetrieveResponse"];
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    updateTickets: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TicketUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
-        };
+  updateTickets: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteTickets: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TicketDeleteRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TicketUpdateRequest"];
+      };
     };
-    updatePerformance: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PerformanceUpdateRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseVoid"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePerformanceUpdateResponse"];
-                };
-            };
-        };
+      };
     };
-    createPerformance: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PerformanceRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePerformanceResponse"];
-                };
-            };
-        };
+  };
+  cancelTickets: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    signUp: {
-        parameters: {
-            query: {
-                authorizationCode: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MemberLoginRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseLoginSuccessResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TicketCancelRequest"];
+      };
     };
-    signOut: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseVoid"];
         };
+      };
     };
-    createMemberBooking: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MemberBookingRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseMemberBookingResponse"];
-                };
-            };
-        };
+  };
+  updatePerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    createGuestBookings: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GuestBookingRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseGuestBookingResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PerformanceModifyRequest"];
+      };
     };
-    getGuestBookings: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description 공연 정보 수정 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GuestBookingRetrieveRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseListGuestBookingRetrieveResponse"];
-                };
-            };
+      };
+      /** @description 잘못된 요청 - 회차 최대 개수 초과 */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyResponse"];
+        };
+      };
+      /** @description 권한 없음 - 해당 공연의 소유자가 아닙니다. */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyResponse"];
+        };
+      };
+      /** @description 존재하지 않는 회원 ID로 수정 요청을 보낼 수 없습니다. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyResponse"];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyResponse"];
+        };
+      };
     };
-    healthcheck: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
+  };
+  createPerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    refreshToken: {
-        parameters: {
-            query: {
-                refreshToken: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseAccessTokenGetSuccess"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PerformanceRequest"];
+      };
     };
-    getTickets: {
-        parameters: {
-            query: {
-                memberId: number;
-                scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
-                isPaymentCompleted?: boolean;
-            };
-            header?: never;
-            path: {
-                performanceId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTicketRetrieveResponse"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceResponse"];
         };
+      };
     };
-    getTicketAvailability: {
-        parameters: {
-            query: {
-                purchaseTicketCount: number;
-            };
-            header?: never;
-            path: {
-                scheduleId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTicketAvailabilityResponse"];
-                };
-            };
-        };
+  };
+  signUp: {
+    parameters: {
+      query: {
+        authorizationCode: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getPerformanceForEdit: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path: {
-                performanceId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePerformanceEditResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["MemberLoginRequest"];
+      };
     };
-    deletePerformance: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path: {
-                performanceId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseLoginSuccessResponse"];
         };
+      };
     };
-    getUserPerformances: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseMakerPerformanceResponse"];
-                };
-            };
-        };
+  };
+  signOut: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getPerformanceDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                performanceId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePerformanceDetailResponse"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseVoid"];
         };
+      };
     };
-    getBookingPerformanceDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                performanceId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseBookingPerformanceDetailResponse"];
-                };
-            };
-        };
+  };
+  createMemberBooking: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getHomePerformanceList: {
-        parameters: {
-            query?: {
-                genre?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseHomeResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["MemberBookingRequest"];
+      };
     };
-    getPresignedUrls: {
-        parameters: {
-            query: {
-                posterImage: string;
-                castImages?: string[];
-                staffImages?: string[];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": {
-                        [key: string]: {
-                            [key: string]: string;
-                        };
-                    };
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseMemberBookingResponse"];
         };
+      };
     };
-    getMemberBookings: {
-        parameters: {
-            query: {
-                memberId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseMemberBookingRetrieveResponse"];
-                };
-            };
-        };
+  };
+  createGuestBookings: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["GuestBookingRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseGuestBookingResponse"];
+        };
+      };
+    };
+  };
+  getGuestBookings: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["GuestBookingRetrieveRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseListGuestBookingRetrieveResponse"];
+        };
+      };
+    };
+  };
+  healthcheck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  refreshToken: {
+    parameters: {
+      query: {
+        refreshToken: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseAccessTokenGetSuccess"];
+        };
+      };
+    };
+  };
+  getTickets: {
+    parameters: {
+      query: {
+        memberId: number;
+        scheduleNumber?: "FIRST" | "SECOND" | "THIRD";
+        bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
+      };
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseTicketRetrieveResponse"];
+        };
+      };
+    };
+  };
+  getTicketAvailability: {
+    parameters: {
+      query: {
+        purchaseTicketCount: number;
+      };
+      header?: never;
+      path: {
+        scheduleId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseTicketAvailabilityResponse"];
+        };
+      };
+    };
+  };
+  getPerformanceForEdit: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceModifyDetailResponse"];
+        };
+      };
+    };
+  };
+  deletePerformance: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseVoid"];
+        };
+      };
+    };
+  };
+  getUserPerformances: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseMakerPerformanceResponse"];
+        };
+      };
+    };
+  };
+  getPerformanceDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponsePerformanceDetailResponse"];
+        };
+      };
+    };
+  };
+  getBookingPerformanceDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        performanceId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseBookingPerformanceDetailResponse"];
+        };
+      };
+    };
+  };
+  getHomePerformanceList: {
+    parameters: {
+      query?: {
+        genre?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseHomeResponse"];
+        };
+      };
+    };
+  };
+  getPresignedUrls: {
+    parameters: {
+      query: {
+        posterImage: string;
+        castImages?: string[];
+        staffImages?: string[];
+        performanceImages?: string[];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": {
+            [key: string]: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  getMemberBookings: {
+    parameters: {
+      query: {
+        memberId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SuccessResponseMemberBookingRetrieveResponse"];
+        };
+      };
+    };
+  };
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #370 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 상세 이미지 리스트인 performanceImageList를 props로 받는 DetailImage 컴포넌트를 추가했습니다!

## 📢 To Reviewers

- 예매하기 페이지의 step3 에서도 정상 동작하도록 테스트 해야합니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="319" alt="Screenshot 2024-08-29 at 10 17 21 PM" src="https://github.com/user-attachments/assets/98ba339d-c4e6-4647-999a-6ac3a88716ee">


## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
