### PR TITLE
[Feat/#372] 예매 조회 페이지 취소 상태 추가

### DIFF
--- a/src/constants/bookingStatus.ts
+++ b/src/constants/bookingStatus.ts
@@ -5,3 +5,7 @@ export const bookingStatusText = {
 };
 
 export type bookingStatusTypes = keyof typeof bookingStatusText;
+
+export interface DefaultDepositProps {
+  $status;
+}

--- a/src/constants/bookingStatus.ts
+++ b/src/constants/bookingStatus.ts
@@ -1,0 +1,7 @@
+export const bookingStatusText = {
+  CHECKING_PAYMENT: "입금 확인 예정",
+  BOOKING_CONFIRMED: "입금 완료",
+  BOOKING_CANCELLED: "예매 취소",
+};
+
+export type bookingStatusTypes = keyof typeof bookingStatusText;

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -50,7 +50,6 @@ const Lookup = () => {
 
   const handleSheetOpen = (bookingId: number) => {
     setSelectedBookingId(bookingId);
-    console.log(lookUpList);
   };
 
   const handleSheetClose = () => {

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -33,6 +33,7 @@ interface LookupProps {
   accountNumber: string;
   accountHolder: string;
   dueDate: number;
+  bookingStatus: string;
   isPaymentCompleted: boolean;
   createdAt: string;
   posterImage: string;
@@ -49,6 +50,7 @@ const Lookup = () => {
 
   const handleSheetOpen = (bookingId: number) => {
     setSelectedBookingId(bookingId);
+    console.log(lookUpList);
   };
 
   const handleSheetClose = () => {

--- a/src/pages/lookup/components/LookupCard.styled.ts
+++ b/src/pages/lookup/components/LookupCard.styled.ts
@@ -1,9 +1,6 @@
 import styled, { css } from "styled-components";
 import { IconArrowRight } from "@assets/svgs";
-
-interface DefaultDepositPropTypes {
-  $status;
-}
+import { DefaultDepositProps } from "@constants/bookingStatus";
 
 export const LookupCardWrapper = styled.section`
   display: flex;
@@ -95,7 +92,7 @@ export const DepositLayout = styled.section`
   justify-content: center;
 `;
 
-export const CheckingDeposit = styled.div<DefaultDepositPropTypes>`
+export const CheckingDeposit = styled.div<DefaultDepositProps>`
   display: flex;
   ${({ $status }) => {
     switch ($status) {

--- a/src/pages/lookup/components/LookupCard.styled.ts
+++ b/src/pages/lookup/components/LookupCard.styled.ts
@@ -1,5 +1,9 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { IconArrowRight } from "@assets/svgs";
+
+interface DefaultDepositPropTypes {
+  $status;
+}
 
 export const LookupCardWrapper = styled.section`
   display: flex;
@@ -91,18 +95,26 @@ export const DepositLayout = styled.section`
   justify-content: center;
 `;
 
-export const CheckingDeposit = styled.div`
+export const CheckingDeposit = styled.div<DefaultDepositPropTypes>`
   display: flex;
+  ${({ $status }) => {
+    switch ($status) {
+      case "CHECKING_PAYMENT":
+        return css`
+          color: ${({ theme }) => theme.colors.yellow_400};
+        `;
+      case "BOOKING_CONFIRMED":
+        return css`
+          color: ${({ theme }) => theme.colors.green};
+        `;
+      case "BOOKING_CANCELLED":
+        return css`
+          color: ${({ theme }) => theme.colors.red};
+        `;
+    }
+  }}
 
   ${({ theme }) => theme.fonts["caption2-medi"]};
-  color: ${({ theme }) => theme.colors.red};
-`;
-
-export const CheckedDeposit = styled.div`
-  display: flex;
-
-  ${({ theme }) => theme.fonts["caption2-medi"]};
-  color: ${({ theme }) => theme.colors.green};
 `;
 
 export const AccountLayout = styled.button`

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -97,14 +97,9 @@ const LookupCard = ({
         <S.Context>
           <S.SubTitle>입금상태</S.SubTitle>
           <S.DepositLayout>
-            {/* {isPaymentCompleted ? (
-              <S.CheckedDeposit>입금 완료</S.CheckedDeposit>
-            ) : (
-              <S.CheckingDeposit>입금 확인 중</S.CheckingDeposit>
-            )} */}
-            <S.CheckedDeposit>
+            <S.CheckingDeposit $status={bookingStatus}>
               {bookingStatusText[bookingStatus as bookingStatusTypes]}
-            </S.CheckedDeposit>
+            </S.CheckingDeposit>
           </S.DepositLayout>
         </S.Context>
         {dueDate >= 0 && totalPaymentAmount > 0 ? (

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -102,7 +102,7 @@ const LookupCard = ({
             </S.CheckingDeposit>
           </S.DepositLayout>
         </S.Context>
-        {dueDate >= 0 && totalPaymentAmount > 0 ? (
+        {dueDate >= 0 && totalPaymentAmount > 0 && bookingStatus === "CHECKING_PAYMENT" ? (
           <S.AccountLayout onClick={() => handleModal(getBankNameKr(bankName), accountNumber)}>
             <S.Account>계좌번호</S.Account>
           </S.AccountLayout>

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -1,6 +1,7 @@
 import { useModal } from "@hooks";
 import BankAccount from "@pages/test/modalTest/BankAccount";
 import { getBankNameKr } from "@utils/getBankName";
+import { bookingStatusText, bookingStatusTypes } from "@constants/bookingStatus";
 import { useNavigate } from "react-router-dom";
 import { LookupProps } from "../types/lookupType";
 import * as S from "./LookupCard.styled";
@@ -30,13 +31,6 @@ const LookupCard = ({
   };
 
   type ScheduleNumTypes = keyof typeof scheduleNum;
-
-  const bookingStatusText = {
-    CHECKING_PAYMENT: "입금 확인 예정",
-    BOOKING_CONFIRMED: "입금 완료",
-    BOOKING_CANCELLED: "예매 취소",
-  };
-  type bookingStatusTypes = keyof typeof bookingStatusText;
 
   const createdAtString = createdAt.slice(0, 10);
   const createDataArray = createdAtString.split("-");

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -19,6 +19,7 @@ const LookupCard = ({
   accountHolder,
   accountNumber,
   dueDate,
+  bookingStatus,
   totalPaymentAmount,
 }: LookupProps) => {
   const navigate = useNavigate();
@@ -30,6 +31,13 @@ const LookupCard = ({
   };
 
   type ScheduleNumTypes = keyof typeof scheduleNum;
+
+  const bookingStatusText = {
+    CHECKING_PAYMENT: "입금 확인 예정",
+    BOOKING_CONFIRMED: "입금 완료",
+    BOOKING_CANCELLED: "예매 취소",
+  };
+  type bookingStatusTypes = keyof typeof bookingStatusText;
 
   const createdAtString = createdAt.slice(0, 10);
   const createDataArray = createdAtString.split("-");
@@ -89,11 +97,14 @@ const LookupCard = ({
         <S.Context>
           <S.SubTitle>입금상태</S.SubTitle>
           <S.DepositLayout>
-            {isPaymentCompleted ? (
+            {/* {isPaymentCompleted ? (
               <S.CheckedDeposit>입금 완료</S.CheckedDeposit>
             ) : (
               <S.CheckingDeposit>입금 확인 중</S.CheckingDeposit>
-            )}
+            )} */}
+            <S.CheckedDeposit>
+              {bookingStatusText[bookingStatus as bookingStatusTypes]}
+            </S.CheckedDeposit>
           </S.DepositLayout>
         </S.Context>
         {dueDate >= 0 && totalPaymentAmount > 0 ? (

--- a/src/pages/lookup/components/LookupCard.tsx
+++ b/src/pages/lookup/components/LookupCard.tsx
@@ -13,7 +13,6 @@ const LookupCard = ({
   scheduleNumber,
   performanceVenue,
   purchaseTicketCount,
-  isPaymentCompleted,
   bankName,
   bookerName,
   accountHolder,

--- a/src/pages/lookup/components/LookupWrapper.tsx
+++ b/src/pages/lookup/components/LookupWrapper.tsx
@@ -13,16 +13,16 @@ const LookupWrapper = ({ handleBtn, ...item }: LookupProps) => {
         <S.LookupCardLeft>
           <S.LookupImage src={item.posterImage} />
           <Label dueDate={item.dueDate} />
-          {item.dueDate >= 0 ? (
+          {item.dueDate < 0 || item.bookingStatus === "BOOKING_CANCELLED" ? (
+            <Button variant="line" disabled={true} size={{ width: "10.8rem", height: "3.6rem" }}>
+              취소하기
+            </Button>
+          ) : (
             <Button
               variant="line"
               size={{ width: "10.8rem", height: "3.6rem" }}
               onClick={handleBtn}
             >
-              취소하기
-            </Button>
-          ) : (
-            <Button variant="line" disabled={true} size={{ width: "10.8rem", height: "3.6rem" }}>
               취소하기
             </Button>
           )}

--- a/src/pages/lookup/types/lookupType.ts
+++ b/src/pages/lookup/types/lookupType.ts
@@ -15,6 +15,7 @@ export interface LookupProps {
   accountNumber: string;
   accountHolder: string;
   dueDate: number;
+  bookingStatus: string;
   isPaymentCompleted: boolean;
   createdAt: string;
   posterImage: string;

--- a/src/pages/lookup/types/lookupType.ts
+++ b/src/pages/lookup/types/lookupType.ts
@@ -16,7 +16,6 @@ export interface LookupProps {
   accountHolder: string;
   dueDate: number;
   bookingStatus: string;
-  isPaymentCompleted: boolean;
   createdAt: string;
   posterImage: string;
   totalPaymentAmount: number;


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #372 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 예매 조회 페이지 내 취소 상태 추가
- [x] 예매 취소 시 취소하기 버튼 비활성화
- [x] 예매 취소 시 계좌번호 버튼 비활성화

## 📢 To Reviewers

- 딱히 전달 사항은 없구,,, 예매 조회 페이지 내 취소 상태 추가했으며 취소 시에 취소하기 버튼과 계좌번호 버튼 비활성화 했습니다!
- 기존에 사용하는 색이 두 가지 뿐이었어서 그냥 컴포넌트 두 개 만들었는데 컴포넌트 세 개를 쓰는 건 비효율적인 것 같아서 status에 따라서 색 변하도록 설정했습니다!
- **코드리뷰 반영 사항** :  `bookingStatusText` 관련해서 공통으로 빼는 게 더 좋을 것 같다는 코드리뷰가 있어 반영했습니다!! bookingStatus API 사용하는 페이지 있다면 저기서 사용하면 좋을 것 같아요~

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/354c885d-8ccc-44bd-8104-03cf649be101)
![image](https://github.com/user-attachments/assets/27c823a3-cd66-4237-93d0-ec9a663318c5)
![image](https://github.com/user-attachments/assets/072a3e66-d390-4d40-a106-3988aec6429f)



