### PR TITLE
[Feat/#398] 종료된 공연 수정 막기

### DIFF
--- a/src/pages/myRegisterdShow/components/registeredcard/RegisteredCard.tsx
+++ b/src/pages/myRegisterdShow/components/registeredcard/RegisteredCard.tsx
@@ -1,5 +1,6 @@
 import Button from "@components/commons/button/Button";
 import Label from "@components/commons/label/Label";
+import { useModal } from "@hooks";
 import { SHOW_TYPE, SHOW_TYPE_KEY, ShowTypes } from "@pages/gig/constants";
 import { useNavigate } from "react-router-dom";
 import { RegisteredObjProps } from "../../constants/myRegisterShow";
@@ -14,9 +15,18 @@ const RegisteredCard = ({
   posterImage,
 }: RegisteredObjProps) => {
   const navigate = useNavigate();
+  const { openAlert, closeAlert } = useModal();
   //공연 수정하기 뷰 연결하고 나면 url 변경해야할 수도 있음
   // 또한, 파라미터를 넘겨서 조회할 수 있도록 url에 파라미터를 추가해야할 수 있음.
   const handleModifiyBtn = () => {
+    if (dueDate < 0) {
+      openAlert({
+        title: "종료된 공연은 수정하실 수 없습니다.",
+        okText: "확인",
+        okCallback: closeAlert,
+      });
+      return;
+    }
     navigate(`/gig-modify-manage/${param}`);
   };
 

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -194,9 +194,9 @@ const TicketHolderList = () => {
     setIsEditMode(false);
 
     //원 상태도 되돌림 (입금 여부 수정, 삭제용 체크)
-    //Todo : 새로고침 후 편집 -> 닫기 반복 클릭하면 에러 발생
-    refetch();
-    setPaymentData(data?.bookingList ?? []);
+    //Todo : 새로고침 후 편집 -> 닫기 반복 클릭하면 에러 발생(빈 배열로 설정되던 에러 + 이상한 렌더링) -> 해결
+    const refetchData = await refetch();
+    setPaymentData(refetchData?.data?.bookingList ?? []);
     setPatchFormData({
       performanceId: Number(performanceId),
       bookingList: [],

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -48,9 +48,9 @@ const headers = [
   { label: "예매상태", key: "bookingStatus" },
 ];
 
-const CSVDataArr: CSVDataType[] = [];
-
 const TicketHolderList = () => {
+  const [CSVDataArr, setCSVDataArr] = useState<CSVDataType[]>([]);
+
   const { performanceId } = useParams();
   const [reservedCount, setReservedCount] = useState(0);
 
@@ -93,13 +93,15 @@ const TicketHolderList = () => {
       setInitBookingStatuses(immutableBookingStatuses);
 
       //전체 데이터를 기반으로 csv 추출 데이터 구축
+      const tempCSVDataArr: CSVDataType[] = [];
+
       data.bookingList.map((item) => {
         const date = item.createdAt.split("T")[0];
         const time = item.createdAt.split("T")[1].slice(0, 5);
         const formattedDate = date?.replace(/-/g, ".");
         const formattedCreateTime = `${formattedDate} ${time}`;
 
-        CSVDataArr.push({
+        tempCSVDataArr.push({
           createdAt: formattedCreateTime,
           scheduleNumber: `${convertingNumber(item.scheduleNumber)}회차`,
           bookerName: item.bookerName,
@@ -107,6 +109,8 @@ const TicketHolderList = () => {
           bookerPhoneNumber: item.bookerPhoneNumber,
           bookingStatus: convertingBookingStatus(item.bookingStatus),
         });
+
+        setCSVDataArr(tempCSVDataArr);
       });
     }
   }, [data]);

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -196,7 +196,7 @@ const TicketHolderList = () => {
     //원 상태도 되돌림 (입금 여부 수정, 삭제용 체크)
     //Todo : 새로고침 후 편집 -> 닫기 반복 클릭하면 에러 발생
     refetch();
-    setPaymentData(data?.bookingList);
+    setPaymentData(data?.bookingList ?? []);
     setPatchFormData({
       performanceId: Number(performanceId),
       bookingList: [],

--- a/src/pages/ticketholderlist/components/managercard/ManagerCard.tsx
+++ b/src/pages/ticketholderlist/components/managercard/ManagerCard.tsx
@@ -88,7 +88,12 @@ const ManagerCard = ({
       )}
       <S.ManagerCardLayout
         $isEditMode={isEditMode}
-        onClick={() => handleCheckBox(bookingId as number)}
+        onClick={() => {
+          if (alreadyBookingConfirmed) {
+            return;
+          }
+          isEditMode && handleCheckBox(bookingId as number);
+        }}
       >
         <S.ManagerCardBox>
           <S.ManagerCardTextBox>

--- a/src/pages/ticketholderlist/components/managercard/ManagerCard.tsx
+++ b/src/pages/ticketholderlist/components/managercard/ManagerCard.tsx
@@ -86,7 +86,10 @@ const ManagerCard = ({
           alreadyBookingConfirmed={alreadyBookingConfirmed}
         />
       )}
-      <S.ManagerCardLayout $isEditMode={isEditMode}>
+      <S.ManagerCardLayout
+        $isEditMode={isEditMode}
+        onClick={() => handleCheckBox(bookingId as number)}
+      >
         <S.ManagerCardBox>
           <S.ManagerCardTextBox>
             <S.ManagerCardTextContent>{bookername}</S.ManagerCardTextContent>
@@ -101,6 +104,7 @@ const ManagerCard = ({
           </S.ManagerCardTextBox>
         </S.ManagerCardBox>
       </S.ManagerCardLayout>
+
       <S.ManagerCardRadioLayout>
         <S.ManagerCardRadioBox $isEditMode={isEditMode}>
           <S.ManagerCardRadioText $isPaid={isPaid === "BOOKING_CONFIRMED"}>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #398 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

- 종료된 공연일 경우, 수정 페이지에 접근이 불가능하도록 구현했습니다.
- 수정 자체를 막으려면 서버 측 작업이 필요하여 요청해두겠습니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
![image](https://github.com/user-attachments/assets/be341907-2fde-4f42-9d3b-20c39393fca6)


## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
