### PR TITLE
[Fix/#410] 이미지 에디터 비율 고정 수정

### DIFF
--- a/src/components/commons/imageEditor/ImageEditor.styled.ts
+++ b/src/components/commons/imageEditor/ImageEditor.styled.ts
@@ -38,9 +38,7 @@ export const CustomReactCrop = styled(ReactCrop)<{
     left: 50%;
     box-sizing: border-box;
     width: ${({ calculatedSize }) => calculatedSize.width}rem;
-    max-width: 100%;
     height: ${({ calculatedSize }) => calculatedSize.height}rem;
-    max-height: 80%;
 
     transform: translate(-50%, -50%);
     border: 0.2rem solid ${({ theme }) => theme.colors.white};

--- a/src/components/commons/imageEditor/ImageEditor.tsx
+++ b/src/components/commons/imageEditor/ImageEditor.tsx
@@ -59,8 +59,8 @@ const ImageEditor = ({ file, aspectRatio, onCropped }: ImageEditorProps) => {
   useEffect(() => {
     if (imageSize.width > 0 && imageSize.height > 0) {
       // 렌더링된 이미지 크기 계산
-      const renderedWidth = 32;
-      const renderedHeight = (imageSize.height / imageSize.width) * renderedWidth;
+      const renderedWidth = imageRef.current.clientWidth / 10;
+      const renderedHeight = imageRef.current.clientHeight / 10;
 
       // 100으로 초기화했던 크롭 영역의 최대 크기 계산
       const maxWidth = (crop.width / 100) * renderedWidth;


### PR DESCRIPTION

<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #410 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 32로 고정해둔 width 변경

## 📢 To Reviewers

- 렌더링 이미지 크기 동적으로 받아오기

## 📸 스크린샷
<img width="268" alt="image" src="https://github.com/user-attachments/assets/40efd980-8bf0-42e2-8283-58c43e298ef5">
<img width="260" alt="image" src="https://github.com/user-attachments/assets/a42bf0a1-909d-4aa7-9ac8-2999fadeaf61">

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
