### PR TITLE
[Fix/#429] 예약 페이지에서 모든 스케쥴의 예매 가능 여부를 확인하도록 수정

### DIFF
--- a/src/pages/book/Book.tsx
+++ b/src/pages/book/Book.tsx
@@ -30,11 +30,13 @@ const Book = () => {
 
   useEffect(() => {
     if (data) {
-      const isBookingAvailable = data?.scheduleList[data?.scheduleList.length - 1]?.isBooking;
+      const isAllBookingUnavailable = data?.scheduleList?.every(
+        (schedule) => schedule.isBooking === false
+      );
 
-      if (!isBookingAvailable) {
+      if (isAllBookingUnavailable) {
         openAlert({
-          title: "종료된 공연입니다.",
+          title: "예매가 마감되었습니다.",
           okText: "확인",
           okCallback: () => {
             navigate(`/gig/${performanceId}`);

--- a/src/pages/gig/Gig.tsx
+++ b/src/pages/gig/Gig.tsx
@@ -125,7 +125,7 @@ const Gig = () => {
       />
       <S.FooterContainer>
         <Button onClick={handleBookClick} disabled={!isBookingAvailable}>
-          {isBookingAvailable ? "예매하기" : "종료된 공연은 예매할 수 없습니다."}
+          {isBookingAvailable ? "예매하기" : "마감된 공연입니다."}
         </Button>
       </S.FooterContainer>
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #429 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지금까지는 맨 마지막의 공연 여부를 확인해서 예매 페이지의 접근 여부를 확인했었는데, 
이 방법으로는 마지막 공연이 예매가 불가능하면, 예매 페이지로의 접근 후, 이전 공연을 예매하지 못해
모든 공연의 예매 가능 여부를 확인하는 로직으로 변경하였습니다.

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
[상세 공연 조회 페이지]
<img width="312" alt="image" src="https://github.com/user-attachments/assets/a32f7e2f-2738-4c3d-84c7-a072f4fa9c86">

[모든 공연이 매진 혹은 종료 이후, 예매 페이지 접근 시]
<img width="297" alt="image" src="https://github.com/user-attachments/assets/c026739e-1cd3-4d22-b21c-98d7e2882dcf">



## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
