### PR TITLE
[Bug/#433] '공연 수정하기' 에서 cast 미리보기 안 뜨는 문제 + 추가된 회차에 예매한 경우 csv에 반영 안되는 문제

### DIFF
--- a/src/apis/domains/performances/queries.ts
+++ b/src/apis/domains/performances/queries.ts
@@ -31,7 +31,7 @@ export const useMakerPerformance = () => {
     queryKey: [PERFORMANCE_QUERY_KEY.DETAIL],
     queryFn: getMakerPerformance,
     // staleTime: 1000 * 60 * 60,
-    gcTime: 1000 * 60 * 60 * 24,
+    gcTime: 0,
   });
 };
 

--- a/src/pages/modifyManage/ModifyMaker.tsx
+++ b/src/pages/modifyManage/ModifyMaker.tsx
@@ -78,6 +78,8 @@ const ModifyManageMaker = ({
     handleModifyManageStep();
   };
 
+  console.log(castModifyRequests);
+  console.log(staffModifyRequests);
   return (
     <>
       <S.ModifyManageContainer>

--- a/src/pages/modifyManage/ModifyMaker.tsx
+++ b/src/pages/modifyManage/ModifyMaker.tsx
@@ -78,8 +78,6 @@ const ModifyManageMaker = ({
     handleModifyManageStep();
   };
 
-  console.log(castModifyRequests);
-  console.log(staffModifyRequests);
   return (
     <>
       <S.ModifyManageContainer>

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -305,6 +305,7 @@ const ModifyManage = () => {
   //비즈니스 로직 분리 - 공연 수정하기 PUT 요청
   const handleComplete = async () => {
     const { data, isSuccess } = await refetch();
+    //presignedUrl로 받아온 데이터들을 저장할 변수
     let posterUrls: string[];
     let castUrls: string[];
     let staffUrls: string[];
@@ -314,6 +315,7 @@ const ModifyManage = () => {
       return;
     } else if (isSuccess) {
       const extractUrls = (data: PresignedResponse) => {
+        //앞부분(유효한 부분)만 떼어내서 저장(뒷 부분은 사진이 뜨는 url이 아님)
         posterUrls = Object.values(data.poster).map((url) => url.split("?")[0]);
         castUrls = Object.values(data.cast).map((url) => url.split("?")[0]);
         staffUrls = Object.values(data.staff).map((url) => url.split("?")[0]);
@@ -322,8 +324,10 @@ const ModifyManage = () => {
         return [...posterUrls, ...castUrls, ...staffUrls, ...performanceUrls];
       };
 
+      //배열 형태로 추출된 모든 presignedUrls
       const S3Urls = extractUrls(data);
 
+      //기존에 갖고 있던 이미지들의 주소들 -> files
       const files = [
         dataState.posterImage,
         ...dataState.castModifyRequests.map((cast) => cast.castPhoto),
@@ -336,10 +340,14 @@ const ModifyManage = () => {
           S3Urls.map(async (url, index) => {
             const file = files[index];
 
+            //여기 왜 fetch하는거지? 그냥 받아오면 안되는건가? -> blob 메서드를 사용하려면 response 타입이 필요하기 때문
             const response = await fetch(file);
+
+            //blob타입으로 변환 과정
             const blob = await response.blob();
             const newFile = new File([blob], `fileName-${new Date()}`, { type: blob.type });
 
+            //새롭게 받은 url에 해당 파일 저장
             return putS3({ url, file: newFile });
           })
         );

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -810,6 +810,8 @@ const ModifyManage = () => {
     }
 
     if (modifyState.modifyManageStep === 3) {
+      console.log(dataState.castModifyRequests);
+      console.log(dataState.staffModifyRequests);
       return (
         <>
           <MetaTag title="공연 수정" />
@@ -838,12 +840,10 @@ const ModifyManage = () => {
             contact={dataState.performanceContact as string}
             teamName={dataState.performanceTeamName as string}
             castList={
-              dataState.castModifyRequests?.[0]?.castId === -1
-                ? []
-                : (dataState.castModifyRequests?.map((cast, index) => ({
-                    ...cast,
-                    //castId: index + 1,
-                  })) as Cast[])
+              dataState.castModifyRequests?.map((cast, index) => ({
+                ...cast,
+                //castId: index + 1,
+              })) as Cast[]
             }
             staffList={
               dataState.staffModifyRequests?.map((cast, index) => ({

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -807,8 +807,6 @@ const ModifyManage = () => {
     }
 
     if (modifyState.modifyManageStep === 2) {
-      console.log(dataState.castModifyRequests);
-      console.log(dataState.staffModifyRequests);
       return (
         <ModifyManageMaker
           castModifyRequests={dataState.castModifyRequests as Cast[]}

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -210,7 +210,7 @@ const ModifyManage = () => {
                 castRole: item.castRole ?? "",
                 castPhoto: item.castPhoto ?? "",
               }))
-            : [{ castId: -1, castName: "", castRole: "", castPhoto: "" }],
+            : [],
           staffModifyRequests: data.staffList?.length
             ? data.staffList.map((item) => ({
                 staffId: item.staffId ?? -1,
@@ -218,7 +218,7 @@ const ModifyManage = () => {
                 staffRole: item.staffRole ?? "",
                 staffPhoto: item.staffPhoto ?? "",
               }))
-            : [{ staffId: -1, staffName: "", staffRole: "", staffPhoto: "" }],
+            : [],
           bankName: data.bankName,
           accountHolder: data.accountHolder,
           performanceImageModifyRequests: data.performanceImageList?.length
@@ -807,6 +807,8 @@ const ModifyManage = () => {
     }
 
     if (modifyState.modifyManageStep === 2) {
+      console.log(dataState.castModifyRequests);
+      console.log(dataState.staffModifyRequests);
       return (
         <ModifyManageMaker
           castModifyRequests={dataState.castModifyRequests as Cast[]}

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -818,8 +818,6 @@ const ModifyManage = () => {
     }
 
     if (modifyState.modifyManageStep === 3) {
-      console.log(dataState.castModifyRequests);
-      console.log(dataState.staffModifyRequests);
       return (
         <>
           <MetaTag title="공연 수정" />

--- a/src/pages/modifyManage/ModifyManage.tsx
+++ b/src/pages/modifyManage/ModifyManage.tsx
@@ -564,7 +564,7 @@ const ModifyManage = () => {
                 value={dataState.performanceTitle}
                 onChange={(e) => handleInputChange("performanceTitle", e.target.value)}
                 placeholder="등록될 공연의 이름을 입력해주세요."
-                maxLength={30}
+                maxLength={18}
                 cap={true}
               />
             </InputModifyManageBox>

--- a/src/pages/modifyManage/components/RoleLayout.tsx
+++ b/src/pages/modifyManage/components/RoleLayout.tsx
@@ -30,6 +30,7 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
     }))
   );
 
+  //처음 딱 들어갔을 때 대기하고 있는 스태프, 캐스트에서는 isNew가 undefined임
   const handelAddRole = () => {
     setMakerList((prev) => [
       ...prev,
@@ -56,7 +57,6 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
   useEffect(() => {
     const newMakerList = makerList.map((role) => {
       if (title === "출연진") {
-        console.log("출연진:", role.isNew);
         return role.isNew
           ? {
               castName: role.makerName,
@@ -71,7 +71,6 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
             };
       }
       if (title === "스태프") {
-        console.log("스태프:", role.isNew);
         return role.isNew
           ? {
               staffName: role.makerName,

--- a/src/pages/modifyManage/components/RoleLayout.tsx
+++ b/src/pages/modifyManage/components/RoleLayout.tsx
@@ -31,6 +31,7 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
   );
 
   //처음 딱 들어갔을 때 대기하고 있는 스태프, 캐스트에서는 isNew가 undefined임
+  //그리고 여전히 makerId : -1로 있음 (동일하게) -> 그래서 처음에 staff 추가누르면 엉뚱하게 사진은 cast에 추가되는 현상 발생
   const handelAddRole = () => {
     setMakerList((prev) => [
       ...prev,

--- a/src/pages/modifyManage/components/RoleLayout.tsx
+++ b/src/pages/modifyManage/components/RoleLayout.tsx
@@ -56,6 +56,7 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
   useEffect(() => {
     const newMakerList = makerList.map((role) => {
       if (title === "출연진") {
+        console.log("출연진:", role.isNew);
         return role.isNew
           ? {
               castName: role.makerName,
@@ -70,6 +71,7 @@ const RoleLayout = ({ list, updateList, title }: RoleLayoutProps) => {
             };
       }
       if (title === "스태프") {
+        console.log("스태프:", role.isNew);
         return role.isNew
           ? {
               staffName: role.makerName,

--- a/src/pages/modifyManage/components/RoleWrapper.tsx
+++ b/src/pages/modifyManage/components/RoleWrapper.tsx
@@ -21,7 +21,6 @@ interface RoleWrapperProps {
 }
 
 const RoleWrapper = ({ id, role, removeRole, onUpdateRole }: RoleWrapperProps) => {
-  console.log("role:", role);
   const { makerName, makerRole, makerPhoto } = role;
   const [postImg, setPostImg] = useState<File | null>(null);
   const [previewImg, setPreviewImg] = useState<string | null>(makerPhoto || null);
@@ -57,7 +56,6 @@ const RoleWrapper = ({ id, role, removeRole, onUpdateRole }: RoleWrapperProps) =
   };
 
   //문제 가능성(원인)2 -> 처음 들어올 때는 항상 -1이고, x버튼 눌렀다가 +누르고 추가하면 newDate로 추가됨.
-  //그리고 저 presigned url 바뀌는 것도 뭔가 연관성이 있어보이기도.. (곧바로 추가하면 이미지 없어지고, 아니면 이미지 보존)
   return (
     <>
       <S.RoleWrapper>

--- a/src/pages/modifyManage/components/RoleWrapper.tsx
+++ b/src/pages/modifyManage/components/RoleWrapper.tsx
@@ -21,6 +21,7 @@ interface RoleWrapperProps {
 }
 
 const RoleWrapper = ({ id, role, removeRole, onUpdateRole }: RoleWrapperProps) => {
+  console.log("role:", role);
   const { makerName, makerRole, makerPhoto } = role;
   const [postImg, setPostImg] = useState<File | null>(null);
   const [previewImg, setPreviewImg] = useState<string | null>(makerPhoto || null);
@@ -55,6 +56,8 @@ const RoleWrapper = ({ id, role, removeRole, onUpdateRole }: RoleWrapperProps) =
     setOpenImageModal(false); // 모달 닫기
   };
 
+  //문제 가능성(원인)2 -> 처음 들어올 때는 항상 -1이고, x버튼 눌렀다가 +누르고 추가하면 newDate로 추가됨.
+  //그리고 저 presigned url 바뀌는 것도 뭔가 연관성이 있어보이기도.. (곧바로 추가하면 이미지 없어지고, 아니면 이미지 보존)
   return (
     <>
       <S.RoleWrapper>

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -373,7 +373,11 @@ const TicketHolderList = () => {
                     </S.FooterButtonText>
                     <S.MarginBottom $value="2.4rem">
                       <Button>
-                        <CSVLink data={CSVDataArr} headers={headers} filename="예매자 목록.csv">
+                        <CSVLink
+                          data={CSVDataArr}
+                          headers={headers}
+                          filename={`${data.performanceTitle}_예매자 목록.csv`}
+                        >
                           예매자 목록 다운받기
                         </CSVLink>
                       </Button>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #433 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

- [x] cast 미리보기에 뜨도록 바꾸기 (수정 반영은 되고 있는 상태)

cast 미리보기에 안 뜨던 원인은 다음과 같습니다.
1. dataState를 fetch해올 때, castList나 staffList 배열의 length가 0인 경우 id를 -1로 갖는 cast 혹은 staff로 초기화
2. 1번으로 인해 modifyManage에서 step 2로 가면 기본적으로 데이터를 추가할 수 있는 형태로 되어 있음

즉, 아래와 같은 모습(a)이 아니라
![image](https://github.com/user-attachments/assets/cef74b96-b8cd-4217-af7b-1d63c1394138)

이와 같은 모습(b)을 보임 (의도된 디자인이었던 것으로 기억)
![image](https://github.com/user-attachments/assets/d7f6e064-6007-4ffa-bdeb-a1012ac276ac)


3. 그러나 modifyManage에서 cast 부분은 id == -1일 경우 뜨지 않게 되어 있었음 -> 수정 (커밋 내역 참고)
4. (a)의 같은 모습에서 추가할 경우에는, id에 new Date.now()가 들어감. -> 그래도, isNew 변수로 걸러낼 수 있음
(만약 -1이었으면 isNew가 없기 때문에 undefined가 뜨는 문제 발생)



- [ ] 추가된 회차 예매한 경우도 csv에 반영되도록 구현하기 
이미 반영 잘 되고 있음.

- [ ] 공연이름 예매자 목록(다운시간)으로 csv이름 으로 csv 파일 명 변경하기 
다운 시간도 써달라고 했는데, 살짝 로직을 틀어야해서 그건 나중에 하겠습니다.


## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
