### PR TITLE
[Fix/#436] 사이드바 하단 잘리는 오류 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  --vh: 100%;
+  --dvh: 100%;
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,8 @@ function App() {
   const queryClient = new QueryClient();
 
   function setScreenSize() {
-    const vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty("--vh", `${vh}px`);
+    const dvh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--dvh", `${dvh}px`);
   }
 
   useEffect(() => {

--- a/src/components/commons/hamburger/Hamburger.styled.ts
+++ b/src/components/commons/hamburger/Hamburger.styled.ts
@@ -29,7 +29,7 @@ export const HamburgerWrapper = styled.section<HamburgerWrapperProps>`
   flex-direction: column;
   gap: 1.6rem;
   width: 25.6rem;
-  height: calc(var(--vh, 1vh) * 100);
+  height: calc(var(--dvh, 1dvh) * 100);
 
   background-color: ${({ theme }) => theme.colors.gray_900};
   transform: ${({ $isOpen }) => ($isOpen ? "translateX(0)" : "translateX(100%)")};


### PR DESCRIPTION
## 📌 관련 이슈번호

- #436 
- merge하고 모바일에서 확인해야 해서 제대로 실행되면 이슈 제가 따로 닫겠습니다! 해결 안 되면 같은 이슈 번호 계속 쓸게요 ㅠㅠ

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

1. vh -> dvh로 변경

## 📢 To Reviewers

<table align="center">
        <tr align="center">
            <th>하단바 있을 때</th>
            <th>하단바 없을 때</th>
        </tr>
        <tr>
            <td><img width="277" alt="image" src="https://github.com/user-attachments/assets/38fa1f33-68b8-4980-838a-818327d26d71"></td>
            <td><img width="308" alt="image" src="https://github.com/user-attachments/assets/922e27f5-4e6e-4bb8-a7b6-7a9b7f02bd38"></td>
        </tr>
    </table>


위 이미지처럼, 사파리 자체 하단바까지 뷰포트로 계산해 사이드바 호출 시 하단이 잘리는 문제가 발견됐습니다!!

사실 기본 세팅은 하단바는 뷰포트로 계산하지 않는 게 기본인데, 이로 인해서 로그아웃 버튼이 하단바 아래로 사라지는 이슈가 있어서 [100vh로 맞추기](https://velog.io/@eunddodi/React-%EB%AA%A8%EB%B0%94%EC%9D%BC-%EC%9B%B9-%EC%95%B1-100vh-%EC%8B%A4%EC%A0%9C-%ED%99%94%EB%A9%B4-%ED%81%AC%EA%B8%B0%EB%A1%9C-%EB%A7%9E%EC%B6%94%EA%B8%B0) 아티클을 참고해 수정했었습니다! 

[관련 commit](https://github.com/TEAM-BEAT/BEAT-Client/commit/eabfc9a5c529cc62944a6fb5b211df36bf736150)

이랬더니 아예 하단바를 뷰포트에 포함하지 않아 사이드바가 잘려서 나와버리는 이슈가 발생했습니다.


이게 뭐라고 수정했나... 싶겠지만!! 원래 innerHeight로 계산하려다가 폭풍 구글링으로 dvh를 이용하면 된다는 글을 읽어서 테스트해보겠습니다! 

## 📸 스크린샷

모바일로 테스트 해야 해서 스크린샷 없어요 ㅠㅠ

## 🔗 참고 자료

[모바일 환경에서 뷰포트 높이, hover CSS로 최적화](https://velog.io/@sargadi/%EB%AA%A8%EB%B0%94%EC%9D%BC-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EB%B7%B0%ED%8F%AC%ED%8A%B8-%EB%86%92%EC%9D%B4-hover-CSS%EB%A1%9C-%EC%B5%9C%EC%A0%81%ED%99%94-hcjvlb2a)