### PR TITLE
[ Refactor/#450 ] Bottom Sheet 상단 padding값 변경 가능하도록 변경

### DIFF
--- a/src/components/commons/bottomSheet/BottomSheet.styled.ts
+++ b/src/components/commons/bottomSheet/BottomSheet.styled.ts
@@ -22,9 +22,10 @@ export const BottomSheetWrapper = styled.section<{ $isOpen: boolean }>`
   animation: ${({ $isOpen }) => ($isOpen ? bottomSheetUp : bottomSheetDown)} 250ms ease-in-out;
 `;
 
-export const BottomSheetLayout = styled.section`
+export const BottomSheetLayout = styled.section<{ $paddingTop?: string }>`
   width: 37.5rem;
-  padding: 3.6rem 2.4rem 2.8rem;
+  padding: ${({ $paddingTop }) =>
+    $paddingTop ? `${$paddingTop} 2.4rem 2.8rem` : "3.6rem 2.4rem 2.8rem"};
 
   background-color: ${({ theme }) => theme.colors.gray_800};
   border-radius: 2rem 2rem 0 0;

--- a/src/components/commons/bottomSheet/BottomSheet.tsx
+++ b/src/components/commons/bottomSheet/BottomSheet.tsx
@@ -6,12 +6,13 @@ export interface BottomSheetPropType {
   isOpen: boolean;
   children?: ReactNode;
   title?: string;
+  paddingTop?: string;
 }
 
-const BottomSheet = ({ isOpen, title, children }: BottomSheetPropType) => {
+const BottomSheet = ({ isOpen, title, paddingTop, children }: BottomSheetPropType) => {
   return (
     <S.BottomSheetWrapper $isOpen={isOpen} onClick={(e) => e.stopPropagation()}>
-      <S.BottomSheetLayout>
+      <S.BottomSheetLayout $paddingTop={paddingTop}>
         <S.Title>{title}</S.Title>
         {children}
       </S.BottomSheetLayout>


### PR DESCRIPTION

## 📌 관련 이슈번호

- Closes #450

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 리팩토링

## ✅ Key Changes

바텀시트 상단 padding값이 고정인데, 이번 스프린트에 상단 padding 값이 달라지는 바텀시트가 두 개 들어와서 바텀시트 상단 padding 값을 props로 조정할 수 있도록 변경하였습니다.

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/1af6c8b8-1c1e-4545-8030-a1ca4d60eb03)

무조건 상단 padding이 3.6rem인데, 3.2rem과 1.2rem이 생겼습니다. ㅠㅠ

