### PR TITLE
[Feat/#470] 토스트 개선, 토스트 유틸 함수 구현, QA 반영

### DIFF
--- a/src/components/commons/mapInput/MapInput.styled.ts
+++ b/src/components/commons/mapInput/MapInput.styled.ts
@@ -101,7 +101,6 @@ export const SearchDropDownWrapper = styled.div`
   overflow: hidden scroll;
 
   background-color: ${({ theme }) => theme.colors.gray_800};
-  border: 1px solid black;
   border-radius: 6px;
 
   &::-webkit-scrollbar {

--- a/src/components/commons/toast/Toast.styled.ts
+++ b/src/components/commons/toast/Toast.styled.ts
@@ -25,12 +25,15 @@ const toastShow = css(["", " 2s forwards;"] as any as TemplateStringsArray, toas
 interface ToastWrapperProps {
   $isVisible: boolean;
   $toastBottom: number;
+  $isTop?: boolean;
 }
 
 export const ToastWrapper = styled.div<ToastWrapperProps>`
   ${Generators.flexGenerator()}
   position: fixed;
-  bottom: ${({ $toastBottom }) => $toastBottom * 0.1}rem;
+
+  ${({ $isTop, $toastBottom }) => ($isTop ? " top: 0.8rem;" : `bottom: ${$toastBottom * 0.1}rem;`)};
+
   z-index: 999;
   display: ${({ $isVisible }) => ($isVisible ? "flex" : "none")};
   gap: 0.8rem;
@@ -39,7 +42,8 @@ export const ToastWrapper = styled.div<ToastWrapperProps>`
   margin: 0 2rem;
   padding: 0 3.2rem 0 1.6rem;
 
-  background-color: ${({ theme }) => theme.colors.gray_900};
+  background-color: ${({ theme, $isTop }) =>
+    $isTop ? theme.colors.gray_800 : theme.colors.gray_900};
   border-radius: 6px;
 
   animation: ${({ $isVisible }) => $isVisible && toastShow};

--- a/src/components/commons/toast/Toast.styled.ts
+++ b/src/components/commons/toast/Toast.styled.ts
@@ -31,7 +31,7 @@ export const ToastWrapper = styled.div<ToastWrapperProps>`
   ${Generators.flexGenerator()}
   position: fixed;
   bottom: ${({ $toastBottom }) => $toastBottom * 0.1}rem;
-  z-index: 1;
+  z-index: 999;
   display: ${({ $isVisible }) => ($isVisible ? "flex" : "none")};
   gap: 0.8rem;
   min-width: 19.2rem;

--- a/src/components/commons/toast/Toast.tsx
+++ b/src/components/commons/toast/Toast.tsx
@@ -5,11 +5,19 @@ interface ToastProps extends HTMLAttributes<HTMLDivElement> {
   icon?: React.ReactNode;
   isVisible: boolean;
   toastBottom?: number;
+  isTop?: boolean;
 }
 
-const Toast = ({ icon, children, isVisible, toastBottom = 3, ...rest }: ToastProps) => {
+const Toast = ({
+  icon,
+  children,
+  isVisible,
+  toastBottom = 3,
+  isTop = false,
+  ...rest
+}: ToastProps) => {
   return (
-    <S.ToastWrapper $isVisible={isVisible} $toastBottom={toastBottom} {...rest}>
+    <S.ToastWrapper $isVisible={isVisible} $toastBottom={toastBottom} $isTop={isTop} {...rest}>
       {icon && <S.ToastIcon>{icon}</S.ToastIcon>}
       <S.ToastMessage>{children}</S.ToastMessage>
     </S.ToastWrapper>

--- a/src/components/commons/toast/Toast.tsx
+++ b/src/components/commons/toast/Toast.tsx
@@ -8,6 +8,7 @@ interface ToastProps extends HTMLAttributes<HTMLDivElement> {
   isTop?: boolean;
 }
 
+//todo: 만약 모든 토스트 위에 위치하게 하고 싶다면, toastBottom 조정 필요
 const Toast = ({
   icon,
   children,

--- a/src/pages/cancel/Cancel.tsx
+++ b/src/pages/cancel/Cancel.tsx
@@ -79,6 +79,7 @@ const Cancel = () => {
     };
 
     confirmCancelAction(requestData);
+    alert("hi");
   };
 
   if (!state) {

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
@@ -111,7 +111,7 @@ const PerformanceIntroduce = ({
                 position: "absolute",
                 top: "1.7rem",
                 right: "2rem",
-                zIndex: "3",
+                zIndex: "1",
                 cursor: "pointer",
               }}
               onClick={handleLinkToKakaoMap}

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
@@ -125,10 +125,13 @@ const PerformanceIntroduce = ({
         </S.Container>
         <S.Divider />
         <Contact contact={contact} />
+
+        <div style={{ width: "100%", display: "flex", justifyContent: "center" }}>
+          <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+            클립보드에 복사되었습니다!
+          </Toast>
+        </div>
       </S.Wrapper>
-      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
-        클립보드에 복사되었습니다!
-      </Toast>
     </>
   );
 };

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -403,8 +403,7 @@ const TicketHolderList = () => {
 
   const handleCopyClipBoard = (text: string) => {
     navigator.clipboard.writeText(text);
-
-    showToast();
+    handleToastVisible("클립보드에 복사되었습니다!", "bottom");
   };
 
   return (

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -50,6 +50,11 @@ export interface FilterListType {
   bookingStatus: string[];
 }
 
+interface ToastConfigProps {
+  message: string;
+  isTop: boolean;
+}
+
 const headers = [
   { label: "예매일시", key: "createdAt" },
   { label: "회차", key: "scheduleNumber" },
@@ -60,6 +65,10 @@ const headers = [
 ];
 
 const TicketHolderList = () => {
+  const [toastConfig, setToastConfig] = useState<ToastConfigProps>({
+    message: "클립보드에 복사되었습니다!",
+    isTop: false,
+  });
   const [paymentData, setPaymentData] = useState<BookingListProps[]>();
 
   // DEFAULT, PAYMENT, REFUND, DELETE
@@ -368,6 +377,8 @@ const TicketHolderList = () => {
     if (csvLinkRef.current) {
       csvLinkRef.current.link.click();
     }
+    setToastConfig({ message: "예매자 리스트가 다운되었습니다.", isTop: true });
+    showToast();
   };
 
   const { setHeader } = useHeader();
@@ -488,8 +499,13 @@ const TicketHolderList = () => {
               filename={`${data.performanceTitle}_예매자 목록.csv`}
               ref={csvLinkRef}
             />
-            <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
-              클립보드에 복사되었습니다!
+            <Toast
+              icon={<IconCheck />}
+              isVisible={isToastVisible}
+              isTop={toastConfig.isTop}
+              toastBottom={30}
+            >
+              {toastConfig.message}
             </Toast>
           </S.TicketHolderListWrpper>
         </>

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -112,6 +112,7 @@ const TicketHolderList = () => {
 
   const { mutate: updateMutate, isPending: updateIsPending } = useTicketUpdate();
 
+  //토스트 메세지, 위치를 정하는 유틸 함수
   const handleToastVisible = (message: string, position: "top" | "bottom") => {
     const isTop = position === "top" ? true : false;
     setToastConfig({ message, isTop });
@@ -192,6 +193,7 @@ const TicketHolderList = () => {
     });
 
     closeConfirm();
+    handleToastVisible("환불 처리되었습니다.", "top");
     setTimeout(() => {
       window.location.reload();
     }, 1000);
@@ -229,6 +231,7 @@ const TicketHolderList = () => {
       bookingList: filteredPaymentData,
     });
     closeConfirm();
+    handleToastVisible("예매자가 삭제되었습니다.", "top");
     setTimeout(() => {
       window.location.reload();
     }, 1000);

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -112,6 +112,12 @@ const TicketHolderList = () => {
 
   const { mutate: updateMutate, isPending: updateIsPending } = useTicketUpdate();
 
+  const handleToastVisible = (message: string, position: "top" | "bottom") => {
+    const isTop = position === "top" ? true : false;
+    setToastConfig({ message, isTop });
+    showToast();
+  };
+
   const handlePaymentFixAxiosFunc = () => {
     if (updateIsPending) {
       return;
@@ -134,6 +140,7 @@ const TicketHolderList = () => {
       bookingList: filteredPaymentData,
     });
     closeConfirm();
+    handleToastVisible("입금 처리되었습니다.", "top");
     setTimeout(() => {
       window.location.reload();
     }, 1000);
@@ -377,8 +384,7 @@ const TicketHolderList = () => {
     if (csvLinkRef.current) {
       csvLinkRef.current.link.click();
     }
-    setToastConfig({ message: "예매자 리스트가 다운되었습니다.", isTop: true });
-    showToast();
+    handleToastVisible("예매자 리스트가 다운되었습니다.", "top");
   };
 
   const { setHeader } = useHeader();


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #470 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용
- [x] 공연장 주소 복사 토스트 위치 조정
- [x] 화살표 버튼이 CTA(목표 달성 버튼)보다 위에 오는 현상 수정 (z-index)
- [x] 주소 검색 모달의 검정색 스토로크 제거
- [x] 상세 공연 페이지 복사 완료 토스트 구현
- [x] 예매자 목록 다운로드 및 입금 & 환불 & 취소 처리 성공 토스트 구현 (피그마 참고)

## 📢 To Reviewers
- 토스트를 편하게 사용할 수 있도록 handleToastVisible 함수를 작성해두었습니다.
추후 유틸 함수로 분리하여 export 해서 사용하는 것도 좋을 것 같습니다! 

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
스크린샷을 보면, 토스트의 배경색이나 위치가 다른 것을 확인할 수 있습니다. 그래서 기존의 Toast 공통 컴포넌트를 기존의 사용 방법에서 포지션을 옵셔널로 정할 경우, 그에 맞게 top용 토스트로 변하도록 개선했습니다.
<img width="938" alt="image" src="https://github.com/user-attachments/assets/117f542b-fdbf-458d-80cd-c76cb784fabc" />

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
