### PR TITLE
[Feat/#481] useToastHandler 훅 추가, 토스트 전부 상단으로 위치 (+ alert 제거), 핑크색으로 글자 칠해지도록 기능 구현

### DIFF
--- a/src/components/commons/bottomSheet/actionsBottomSheet/phoneNumber/PhoneNumber.tsx
+++ b/src/components/commons/bottomSheet/actionsBottomSheet/phoneNumber/PhoneNumber.tsx
@@ -25,7 +25,7 @@ const PhoneNumber = ({ phone }: PhoneNumProps) => {
           <S.Copy />
         </S.PhoneNumLayout>
       </S.PhoneNumWrapper>
-      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+      <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
         클립보드에 복사되었습니다!
       </Toast>
     </>

--- a/src/components/commons/mapInput/MapInput.styled.ts
+++ b/src/components/commons/mapInput/MapInput.styled.ts
@@ -141,7 +141,8 @@ export const DropDownItem = styled.div`
 export const RoadName = styled.p`
   align-self: stretch;
 
-  color: ${({ theme }) => theme.colors.pink_200};
+  color: ${({ theme }) => theme.colors.gray_0};
+  //color: ${({ theme }) => theme.colors.pink_200};
   ${({ theme }) => theme.fonts["body1-normal-semi"]};
   white-space: nowrap;
 `;

--- a/src/components/commons/mapInput/MapInput.tsx
+++ b/src/components/commons/mapInput/MapInput.tsx
@@ -98,6 +98,16 @@ const MapInput = ({
     }
   };
 
+  const matchStringPink = (inputValue: string, result: string) => {
+    const regex = new RegExp(`(${_.escapeRegExp(inputValue)})`, "gi");
+    const highlightedResult = result.replace(
+      regex,
+      (match) => `<span style="color: #FF97C2;">${match}</span>`
+    );
+
+    return <span dangerouslySetInnerHTML={{ __html: highlightedResult }} />;
+  };
+
   useEffect(() => {
     setInputValue(value as string);
     prevValueRef.current = value as string;
@@ -191,7 +201,7 @@ const MapInput = ({
                       setLatitudeLongitude(place.y, place.x); //lat이 y값
                     }}
                   >
-                    <S.RoadName>{place.place_name}</S.RoadName>
+                    <S.RoadName>{matchStringPink(inputValue, place.place_name)}</S.RoadName>
                     <S.PostName>{place.road_address_name}</S.PostName>
                   </S.DropDownItem>
                   {idx !== places.length - 1 && <S.Divider />}

--- a/src/components/commons/mapInput/MapInput.tsx
+++ b/src/components/commons/mapInput/MapInput.tsx
@@ -71,6 +71,7 @@ const MapInput = ({
             const temp = [];
             for (var i = 0; i < data.length; i++) {
               temp.push(data[i]);
+              console.log(data);
             }
             setPlaces(temp);
           } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
@@ -190,8 +191,8 @@ const MapInput = ({
                       setLatitudeLongitude(place.y, place.x); //lat이 y값
                     }}
                   >
-                    <S.RoadName>{place.road_address_name}</S.RoadName>
-                    <S.PostName>{place.address_name}</S.PostName>
+                    <S.RoadName>{place.place_name}</S.RoadName>
+                    <S.PostName>{place.road_address_name}</S.PostName>
                   </S.DropDownItem>
                   {idx !== places.length - 1 && <S.Divider />}
                 </React.Fragment>

--- a/src/components/commons/toast/Toast.tsx
+++ b/src/components/commons/toast/Toast.tsx
@@ -8,7 +8,6 @@ interface ToastProps extends HTMLAttributes<HTMLDivElement> {
   isTop?: boolean;
 }
 
-//todo: 만약 모든 토스트 위에 위치하게 하고 싶다면, toastBottom 조정 필요
 const Toast = ({
   icon,
   children,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,5 +3,6 @@ import useHeader from "./useHeader.ts";
 import useLogin from "./useLogin.ts";
 import useModal from "./useModal.ts";
 import useToast from "./useToast.ts";
+import useToastHandler from "./useToastHandler.ts";
 
-export { useHamburger, useHeader, useLogin, useModal, useToast };
+export { useHamburger, useHeader, useLogin, useModal, useToast, useToastHandler };

--- a/src/hooks/useToastHandler.ts
+++ b/src/hooks/useToastHandler.ts
@@ -6,7 +6,7 @@ interface ToastConfigProps {
   isTop: boolean;
 }
 
-//더욱 간편하게 toast를 사용할 수 있도록 2차 추상화
+//top & bottom, 혹은 메세지를 변경해야하는 경우 사용해야하는 훅
 const useToastHandler = () => {
   const { showToast, isToastVisible } = useToast();
   const [toastConfig, setToastConfig] = useState<ToastConfigProps>({

--- a/src/hooks/useToastHandler.ts
+++ b/src/hooks/useToastHandler.ts
@@ -6,7 +6,7 @@ interface ToastConfigProps {
   isTop: boolean;
 }
 
-//top & bottom, 혹은 메세지를 변경해야하는 경우 사용해야하는 훅
+//top & bottom, 혹은 메세지를 변경해야하는 경우 사용하는 훅 (필수 아님)
 const useToastHandler = () => {
   const { showToast, isToastVisible } = useToast();
   const [toastConfig, setToastConfig] = useState<ToastConfigProps>({

--- a/src/hooks/useToastHandler.ts
+++ b/src/hooks/useToastHandler.ts
@@ -1,0 +1,32 @@
+import { useToast } from "@hooks";
+import { useState } from "react";
+
+interface ToastConfigProps {
+  message: string;
+  isTop: boolean;
+}
+
+//더욱 간편하게 toast를 사용할 수 있도록 2차 추상화
+const useToastHandler = () => {
+  const { showToast, isToastVisible } = useToast();
+  const [toastConfig, setToastConfig] = useState<ToastConfigProps>({
+    message: "클립보드에 복사되었습니다!",
+    isTop: true,
+  });
+
+  //토스트 메세지, 위치를 정하는 유틸 함수
+  const handleToastVisible = (message: string, position: "top" | "bottom") => {
+    const isTop = position === "top" ? true : false;
+    setToastConfig({ message, isTop });
+    showToast();
+  };
+
+  /*
+  toastConfig: Toast 속성에 사용,
+  isToastVisible : Toast의 isVisible 속성에 사용
+  handleToastVisible : Toast를 사용하기 위한 함수
+  */
+  return { toastConfig, isToastVisible, handleToastVisible };
+};
+
+export default useToastHandler;

--- a/src/pages/book/components/paidBook/PaidBook.tsx
+++ b/src/pages/book/components/paidBook/PaidBook.tsx
@@ -89,7 +89,7 @@ const PaidBook = ({
         </S.FloatingWrapper>
       </S.Wrapper>
       <S.DepositBox>
-        <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={52}>
+        <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
           클립보드에 복사되었습니다!
         </Toast>
       </S.DepositBox>

--- a/src/pages/cancel/Cancel.tsx
+++ b/src/pages/cancel/Cancel.tsx
@@ -80,7 +80,6 @@ const Cancel = () => {
     };
 
     confirmCancelAction(requestData);
-    alert("hi");
   };
 
   if (!state) {

--- a/src/pages/gig/components/performanceIntroduce/Contact.tsx
+++ b/src/pages/gig/components/performanceIntroduce/Contact.tsx
@@ -34,7 +34,7 @@ const Contact = ({ contact }: ContactProps) => {
           <S.IconCopy $width={24} $height={24} />
         </S.Contact>
       )}
-      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={100}>
+      <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
         클립보드에 복사되었습니다!
       </Toast>
     </S.ContactContainer>

--- a/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
+++ b/src/pages/gig/components/performanceIntroduce/PerformanceIntroduce.tsx
@@ -127,7 +127,7 @@ const PerformanceIntroduce = ({
         <Contact contact={contact} />
 
         <div style={{ width: "100%", display: "flex", justifyContent: "center" }}>
-          <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+          <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
             클립보드에 복사되었습니다!
           </Toast>
         </div>

--- a/src/pages/test/TestPage.tsx
+++ b/src/pages/test/TestPage.tsx
@@ -93,7 +93,7 @@ const TestPage = () => {
         <Button size="medium" variant="primary" onClick={showToast}>
           토스트 보이기
         </Button>
-        <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+        <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
           클립보드에 복사되었습니다!
         </Toast>
         <Spacing marginBottom="3" />

--- a/src/pages/test/modalTest/BankAccount.tsx
+++ b/src/pages/test/modalTest/BankAccount.tsx
@@ -49,7 +49,7 @@ const BankAccount = ({ bankName, number, accountName, accountNumber, price }: Ba
         </Button>
       </BtnWrapper>
 
-      <Toast icon={<IconCheck />} isVisible={isToastVisible} toastBottom={30}>
+      <Toast icon={<IconCheck />} isVisible={isToastVisible} isTop={true}>
         클립보드에 복사되었습니다!
       </Toast>
     </Wrapper>

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -465,7 +465,7 @@ const TicketHolderList = () => {
 
   const handleCopyClipBoard = (text: string) => {
     navigator.clipboard.writeText(text);
-    handleToastVisible("클립보드에 복사되었습니다!", "bottom");
+    handleToastVisible("클립보드에 복사되었습니다!", "top");
   };
 
   return (

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -27,9 +27,9 @@ import SelectedChips from "./components/selectedChips/SelectedChips";
 import { convertingBookingStatus } from "@constants/convertingBookingStatus";
 import { IconCheck } from "@assets/svgs";
 import Toast from "@components/commons/toast/Toast";
-import { useToast } from "@hooks";
 import NonExistent from "./components/nonExistent/NonExistent.";
 import { getUA, isChrome } from "react-device-detect";
+import { useToastHandler } from "@hooks";
 
 export type PaymentType =
   | "CHECKING_PAYMENT"
@@ -66,10 +66,7 @@ const headers = [
 ];
 
 const TicketHolderList = () => {
-  const [toastConfig, setToastConfig] = useState<ToastConfigProps>({
-    message: "클립보드에 복사되었습니다!",
-    isTop: false,
-  });
+  const { toastConfig, isToastVisible, handleToastVisible } = useToastHandler();
   const [paymentData, setPaymentData] = useState<BookingListProps[]>();
   const [allBookings, setAllBookings] = useState<BookingListProps[]>([]); // 전체 예매자 정보 (필터 적용 안 된)
 
@@ -102,9 +99,7 @@ const TicketHolderList = () => {
     filterList
   );
   const { openConfirm, closeConfirm } = useModal();
-
   const [checkedBookingId, setCheckedBookingId] = useState<number[]>([]);
-  const { showToast, isToastVisible } = useToast();
   // 체크된 리스트 확인
   const handleBookingIdCheck = (bookingId: number) => {
     setCheckedBookingId((prev) =>
@@ -113,13 +108,6 @@ const TicketHolderList = () => {
   };
 
   const { mutate: updateMutate, isPending: updateIsPending } = useTicketUpdate();
-
-  //토스트 메세지, 위치를 정하는 유틸 함수
-  const handleToastVisible = (message: string, position: "top" | "bottom") => {
-    const isTop = position === "top" ? true : false;
-    setToastConfig({ message, isTop });
-    showToast();
-  };
 
   const handlePaymentFixAxiosFunc = () => {
     if (updateIsPending) {


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #481 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

- 추후 toast를 바텀으로 옮겨달라는 요청에 대비하여 toast의 bottom 속성은 살려두었습니다.
- 이에 따라, 메세지가 변하거나 toast의 위치가 유동적으로 변하는 경우에는 useToastHandler 훅을 사용하시면 됩니다.
- useToastHandler 에서는 toastConfig(메세지, 위치)와 toastVisible, handlerToastVisible 등을 반환합니다. 
- useToastHandler는 필수가 아닙니다. 다만 만약 사용할 경우, useToast는 사용할 필요가 없습니다.

이외에도 다른 qa 반영
- 필요 없는 alert 제거
- toast 전부 top으로 이동

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="360" alt="image" src="https://github.com/user-attachments/assets/3254f261-27dd-4233-bb64-f74aabf5efe4" />

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
