### PR TITLE
[Fix/#491] CSV 정렬 우선순위 변경

### DIFF
--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -360,9 +360,22 @@ const TicketHolderList = () => {
         });
       });
 
-      tempCSVDataArr.sort(
-        (obj1, obj2) => new Date(obj1.createdAt).getTime() - new Date(obj2.createdAt).getTime()
-      );
+      tempCSVDataArr.sort((a, b) => {
+        const scheduleDiff = a.scheduleNumber.localeCompare(b.scheduleNumber, "ko", {
+          numeric: true,
+        });
+        if (scheduleDiff !== 0) {
+          return scheduleDiff;
+        }
+
+        const statusDiff = a.bookingStatus.localeCompare(b.bookingStatus, "ko");
+        if (statusDiff !== 0) {
+          return statusDiff;
+        }
+
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      });
+
       setCSVDataArr(tempCSVDataArr);
     }
   }, [data, paymentData, allBookings]);
@@ -389,7 +402,6 @@ const TicketHolderList = () => {
       const targetUrl = "https://www.beatlive.kr/gig-manage";
 
       if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) {
-        // window.location.href = `x-web-search://${targetUrl}`;
         const safariUrl = `safari://${targetUrl.replace(/https?:\/\//i, "")}`;
         window.location.href = safariUrl;
       } else {

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -351,8 +351,8 @@ const TicketHolderList = () => {
         const formattedCreateTime = `${formattedDate} ${time}`;
 
         tempCSVDataArr.push({
-          createdAt: formattedCreateTime,
           scheduleNumber: `${convertingNumber(item.scheduleNumber)}회차`,
+          createdAt: formattedCreateTime,
           bookerName: item.bookerName,
           purchaseTicketCount: `${item.purchaseTicketCount}매`,
           bookerPhoneNumber: item.bookerPhoneNumber,


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #491 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

1. CSV 정렬 순서를 예매일시에서 회차, 입금 상태, 예매일시로 변경하였습니다!
2. 기존 컬럼 순서도 예매일시가 가장 우선이었는데 회차, 예매일시, 이름, 매수, 전화번호, 입금 상태로 변경하였습니다!

## 📢 To Reviewers

- 서버에서 오는 그대로 받으면 된다고 생각했는데 생각해보니까 서버는 우선순위가 입금 상태라서... 그냥 제가 호로롭 정렬했어요~
- 지우가 바로 반영했으면 좋겠다고 해서 리뷰 없이 머지하고 main에 반영할게요!!

