### PR TITLE
[Feat/#510] 메인 페이지, 공연 등록 페이지 관련 믹스패널 로깅

### DIFF
--- a/src/pages/book/components/complete/Complete.tsx
+++ b/src/pages/book/components/complete/Complete.tsx
@@ -4,6 +4,8 @@ import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import FreeBook from "../freeBook/FreeBook";
 import PaidBook from "../paidBook/PaidBook";
+import { trackEvent } from "src/track/track";
+import { TRACK_EVENTS } from "src/track/constants/events";
 
 const Complete = () => {
   const location = useLocation();
@@ -52,6 +54,10 @@ const Complete = () => {
       },
     });
   }, [setHeader]);
+
+  useEffect(() => {
+    trackEvent(TRACK_EVENTS.VIEWED_PAGE_BOOKCOMPLETE);
+  }, []);
 
   return (
     <>

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -28,7 +28,7 @@ const Main = () => {
   };
 
   useEffect(() => {
-    trackEvent(TRACK_EVENTS.PAGE_VIEW, { path: "/main" });
+    trackEvent(TRACK_EVENTS.VIEWED_PAGE_MAIN);
   }, []);
 
   if (isLoading) {

--- a/src/pages/main/components/floating/Floating.tsx
+++ b/src/pages/main/components/floating/Floating.tsx
@@ -3,6 +3,7 @@ import { requestKakaoLogin } from "@utils/kakaoLogin";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as S from "./Floating.styled";
+import { Tracking } from "@components/commons/track/Tracking";
 
 const Floating = () => {
   const navigate = useNavigate();
@@ -48,10 +49,12 @@ const Floating = () => {
 
   return (
     <S.Layer $width={width}>
-      <S.FloatingBtnWrapper $showText={showText} onClick={handleRegister}>
-        <S.TicketIcon />
-        <S.FloatingText $showText={showText}>공연 등록</S.FloatingText>
-      </S.FloatingBtnWrapper>
+      <Tracking event="CLICKED_FLOATING_GIGREGISTER">
+        <S.FloatingBtnWrapper $showText={showText} onClick={handleRegister}>
+          <S.TicketIcon />
+          <S.FloatingText $showText={showText}>공연 등록</S.FloatingText>
+        </S.FloatingBtnWrapper>
+      </Tracking>
     </S.Layer>
   );
 };

--- a/src/pages/main/components/performance/Performance.tsx
+++ b/src/pages/main/components/performance/Performance.tsx
@@ -5,6 +5,7 @@ import Spacing from "@components/commons/spacing/Spacing";
 import { useLogin, useModal } from "@hooks";
 import BannerImg from "../../../../assets/images/banner_basic.png";
 import PerformnaceCard from "./PerformnaceCard";
+import { Tracking } from "@components/commons/track/Tracking";
 
 interface PerfonmanceProps {
   performanceId?: number;
@@ -51,9 +52,11 @@ const Performance = ({ genre, performanceList = [] }: PerformanceComponentProps)
       </S.PerformanceLayout>
       <Spacing marginBottom="3.2" />
       {genre === "ALL" ? (
-        <S.BannerWrapper onClick={handleNavigate}>
-          <S.Banner $image={BannerImg} />
-        </S.BannerWrapper>
+        <Tracking event="CLICKED_BANNER_GIGREGISTER">
+          <S.BannerWrapper onClick={handleNavigate}>
+            <S.Banner $image={BannerImg} />
+          </S.BannerWrapper>
+        </Tracking>
       ) : (
         <></>
       )}

--- a/src/pages/main/components/performance/PerformnaceCard.tsx
+++ b/src/pages/main/components/performance/PerformnaceCard.tsx
@@ -3,25 +3,29 @@ import * as S from "./PerformanceCard.styled";
 
 import Label from "@components/commons/label/Label";
 
+import { Tracking } from "@components/commons/track/Tracking";
+
 const PerformnaceCard = ({ ...item }) => {
   const navigate = useNavigate();
 
   return (
-    <S.PerformanceCardWrapper
-      key={item.performanceId}
-      onClick={() => {
-        navigate(`/gig/${item.performanceId}`);
-      }}
-    >
-      <S.PerformanceImg src={item.posterImage} />
+    <Tracking event="CLICKED_SECTION_GIG" properties={{ gig_id: item.performanceId }}>
+      <S.PerformanceCardWrapper
+        key={item.performanceId}
+        onClick={() => {
+          navigate(`/gig/${item.performanceId}`);
+        }}
+      >
+        <S.PerformanceImg src={item.posterImage} />
 
-      <Label dueDate={item.dueDate} />
-      <S.PerformanceTitleWrapper>
-        <S.PerformanceTitle>{item.performanceTitle}</S.PerformanceTitle>
-        <S.PerformancePeriod>{item.performancePeriod}</S.PerformancePeriod>
-        <S.PerformancePrice>{item.ticketPrice.toLocaleString("en-US")}원</S.PerformancePrice>
-      </S.PerformanceTitleWrapper>
-    </S.PerformanceCardWrapper>
+        <Label dueDate={item.dueDate} />
+        <S.PerformanceTitleWrapper>
+          <S.PerformanceTitle>{item.performanceTitle}</S.PerformanceTitle>
+          <S.PerformancePeriod>{item.performancePeriod}</S.PerformancePeriod>
+          <S.PerformancePrice>{item.ticketPrice.toLocaleString("en-US")}원</S.PerformancePrice>
+        </S.PerformanceTitleWrapper>
+      </S.PerformanceCardWrapper>
+    </Tracking>
   );
 };
 

--- a/src/pages/onBoarding/OnBoarding.tsx
+++ b/src/pages/onBoarding/OnBoarding.tsx
@@ -1,5 +1,12 @@
-const OnBoarding = () => {
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const OnBoarding = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate("/main");
+  }, []);
+
   return null;
 };
-
-export default OnBoarding;

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -50,6 +50,8 @@ import {
   onMinusClick,
   onPlusClick,
 } from "./utils/handleEvent";
+import { trackEvent } from "src/track/track";
+import { TRACK_EVENTS } from "src/track/constants/events";
 
 const Register = () => {
   const { isLogin } = useLogin();
@@ -370,6 +372,10 @@ const Register = () => {
       leftOnClick: handleLeftBtn,
     });
   }, [setHeader, registerStep]);
+
+  useEffect(() => {
+    trackEvent(TRACK_EVENTS.VIEWED_PAGE_GIGREGISTER);
+  }, []);
 
   if (registerStep === 1) {
     return (

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -6,7 +6,7 @@ import Intro from "@pages/intro/Intro";
 import KakaoAuth from "@pages/kakaoAuth/KakaoAuth";
 import Main from "@pages/main/Main";
 import NotFound from "@pages/notFound/NotFound";
-import OnBoarding from "@pages/onBoarding/OnBoarding";
+import { OnBoarding } from "@pages/onBoarding/OnBoarding";
 import { GIG_ROUTES, LOOKUP_ROUTES, MANAGE_ROUTES, REGISTER_ROUTES, TEST_ROUTES } from "@routes";
 import DesktopGlobalStyle from "@styles/desktop";
 import { createBrowserRouter } from "react-router-dom";

--- a/src/track/constants/events.ts
+++ b/src/track/constants/events.ts
@@ -5,6 +5,7 @@ export const TRACK_EVENTS = {
   VIEWED_PAGE_GIG: "Viewed_Page_Gig", // 유저가 공연 상세페이지에 최초 진입 / 리프레시했음
   VIEWED_PAGE_BOOK: "Viewed_Page_Book", // 유저가 예매 페이지에 최초 진입 / 리프레시했음
   VIEWED_PAGE_GIGREGISTER: "Viewed_Page_GigRegister", // 유저가 공연 등록 페이지에 최초 진입 / 리프레시했음
+  VIEWED_PAGE_BOOKCOMPLETE: "Viewed_Page_BookComplete", // 예매가 정상적으로 마무리되어 유저가 예매완료 페이지로 진입함
   VIEWED_OVERLAY_LOGIN: "Viewed_Overlay_Login", // 로그인 바텀시트가 화면에 보임
   VIEWED_OVERLAY_BOOKCONFIRM: "Viewed_Overlay_BookConfirm", // 예매내역 바텀시트가 화면에 보임
 
@@ -14,6 +15,8 @@ export const TRACK_EVENTS = {
   CLICKED_BUTTON_BOOK: "Clicked_Button_Book", // /book에서 ‘예매하기’ 버튼을 클릭함
   CLICKED_BUTTON_BOOKCONFIRM: "Clicked_Button_BookConfirm", // 예매내역 바텀시트 내 ‘예매할게요’ 버튼 클릭
   CLICKED_BUTTON_BOOKCANCEL: "Clicked_Button_BookCancel", // 예매내역 바텀시트 내 ‘다시 할게요’ 버튼 클릭
+  CLICKED_FLOATING_GIGREGISTER: "Clicked_Floating_GigRegister", // 유저가 메인 페이지의 '공연등록' 플로팅 버튼을 클릭함
+  CLICKED_BANNER_GIGREGISTER: "Clicked_Banner_GigRegister", // 유저가 메인 페이지의 '우리의 공연 등록하러 가기' 배너 버튼을 클릭함
 } as const;
 
 export type TrackEventKey = keyof typeof TRACK_EVENTS;

--- a/src/track/constants/events.ts
+++ b/src/track/constants/events.ts
@@ -1,8 +1,10 @@
 export const TRACK_EVENTS = {
   // 페이지 뷰
   PAGE_VIEW: "Page_Viewed",
+  VIEWED_PAGE_MAIN: "Viewed_Page_Main", // 유저가 메인페이지에 최초 진입 / 리프레시했음
   VIEWED_PAGE_GIG: "Viewed_Page_Gig", // 유저가 공연 상세페이지에 최초 진입 / 리프레시했음
-  VIEWED_PAGE_BOOK: "Viewed_Page_Book", // 유저가 예매 페이지에 최초 진입/리프레시했음
+  VIEWED_PAGE_BOOK: "Viewed_Page_Book", // 유저가 예매 페이지에 최초 진입 / 리프레시했음
+  VIEWED_PAGE_GIGREGISTER: "Viewed_Page_GigRegister", // 유저가 공연 등록 페이지에 최초 진입 / 리프레시했음
   VIEWED_OVERLAY_LOGIN: "Viewed_Overlay_Login", // 로그인 바텀시트가 화면에 보임
   VIEWED_OVERLAY_BOOKCONFIRM: "Viewed_Overlay_BookConfirm", // 예매내역 바텀시트가 화면에 보임
 

--- a/src/track/constants/events.ts
+++ b/src/track/constants/events.ts
@@ -17,6 +17,7 @@ export const TRACK_EVENTS = {
   CLICKED_BUTTON_BOOKCANCEL: "Clicked_Button_BookCancel", // 예매내역 바텀시트 내 ‘다시 할게요’ 버튼 클릭
   CLICKED_FLOATING_GIGREGISTER: "Clicked_Floating_GigRegister", // 유저가 메인 페이지의 '공연등록' 플로팅 버튼을 클릭함
   CLICKED_BANNER_GIGREGISTER: "Clicked_Banner_GigRegister", // 유저가 메인 페이지의 '우리의 공연 등록하러 가기' 배너 버튼을 클릭함
+  CLICKED_SECTION_GIG: "Clicked_Section_Gig", // 유저가 메인 페이지의 공연 섹션을 클릭함
 } as const;
 
 export type TrackEventKey = keyof typeof TRACK_EVENTS;

--- a/src/track/useTrackingPageView.ts
+++ b/src/track/useTrackingPageView.ts
@@ -1,10 +1,10 @@
 import mixpanel from "mixpanel-browser";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { trackEvent } from "./track";
 import { TRACK_EVENTS } from "./constants/events";
-import { extractIdFromPath } from "./extractIdFromPath";
 import { TRACKING_CONFIG } from "./constants/trackingConfig";
+import { extractIdFromPath } from "./extractIdFromPath";
+import { trackEvent } from "./track";
 
 export function useTrackingPageView(): void {
   const location = useLocation();
@@ -17,7 +17,14 @@ export function useTrackingPageView(): void {
       if (pathname.includes("complete")) {
         return;
       }
-      const matchedConfig = TRACKING_CONFIG.find((config) => pathname.startsWith(config.path));
+
+      const matchedConfig = TRACKING_CONFIG.find((config) => {
+        const basePath = config.path;
+        return (
+          pathname === basePath || // 정확히 일치
+          pathname.startsWith(`${basePath}/`) // 하위 경로
+        );
+      });
 
       if (matchedConfig) {
         const paramValue = extractIdFromPath(pathname, matchedConfig.path);


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #501 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

- [x] 예매가 정상적으로 마무리되어 유저가 예매완료 페이지로 진입함
- [x] 유저가 메인페이지에 최초 진입 / 리프레시함
- [x] 유저가 메인페이지의 ‘공연등록’ 플로팅 버튼을 클릭함
- [x] 유저가 메인페이지의 ‘우리의 공연 등록하러 가기’ 배너 버튼을 클릭함
- [x] 유저가 메인페이지의 공연 섹션을 클릭함(공연 포스터, 공연명, 공연기간, 가격)
- [x] 유저가 공연 등록 페이지에 최초 진입/리프레시함

## 📢 To Reviewers

- 지우가 바로 사용 가능하냐고 해서 리뷰 없이 바로 main 머지할게요~!
- 현재 `Viewed_Page_{}` 가 페이지마다 달려 있는데 나중에 한 파일로 옮기면 좋을 것 같아요! 일단 지우가 당장 내일부터 사용하고 싶다고 해서 머지 후에 나중에 작업하겠습니다!
- 지금 신지바보 서버 닫혀서 프로덕션 서버로 작업햇어요... 개쫄림이슈로 테스트를 많이 못해봤습니다 ㅠㅠ

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/da7d14ab-645d-4d9d-9199-054a7b66cb27)

