### PR TITLE
[Feat/#511] 공연 등록 성공 후 배포 트리거 로직 추가

### DIFF
--- a/src/apis/domains/performances/queries.ts
+++ b/src/apis/domains/performances/queries.ts
@@ -19,6 +19,7 @@ import {
   postPerformance,
   updatePerformance,
 } from "./api";
+import axios from "axios";
 
 export const PERFORMANCE_QUERY_KEY = {
   DETAIL: "detail",
@@ -158,23 +159,9 @@ export const usePostPerformance = () => {
       });
 
       if (isPerformanceResponse(res) && res.status === 201) {
-        //   // 프리렌더 작업 수행
-        //   const prerenderResponse = await fetch(`${import.meta.env.VITE_CLIENT_URL}/api/prerender`, {
-        //     method: "POST",
-        //     headers: {
-        //       "Content-Type": "application/json",
-        //     },
-        //     body: JSON.stringify({ performanceId: res.data.performanceId }),
-        //   });
-
-        //   console.log("prerenderResponse is: ", prerenderResponse);
-
-        //   if (prerenderResponse.ok) {
-        //     console.log("Prerender successful");
-        //   } else {
-        //     console.error("Prerender failed");
-        //   }
-
+        axios.post(import.meta.env.VITE_DEPLOY_HOOK_URL as string).catch((error) => {
+          console.error("Deployment hook error:", error);
+        });
         // 등록 완료 페이지로 이동
         navigate("/register-complete", {
           state: { performanceId: res.data.performanceId },


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #511

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

공연 등록을 성공하면 vercel에 배포 트리거를 날립니다

## 📢 To Reviewers
공연 페이지를 링크를 sns로 공유할 때 og태그가 미반영이 되는 이슈를 해결하기 위해서 이전에 사전렌더링을 구현했었어요.
그런데 이 부분이 자동화가 되어있지는 않아서 새 공연이 등록할 때마다 수동으로 빌드를 해주고 있었어요.
생각보다 비트에 새롭게 공연이 등록되는 빈도가 (한달에 1번 이상) 많아서 자동화가 필요하다고 생각해서 vercel 배포를 트리거하는 로직을 추가했어요

## 📸 스크린샷
<img width="1752" height="288" alt="image" src="https://github.com/user-attachments/assets/21918c7d-fa08-4058-a6f2-93e0a0e7905d" />
<img width="307" height="225" alt="image" src="https://github.com/user-attachments/assets/f86521cf-bfce-46f6-a69c-b33e2d08ea0c" />
로컬에서 공연 등록했을 때 훅 잘날라가는 것 확인했습니다
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
