### PR TITLE
[Refactor/#521] 캐러셀 presigned 업로드 계약 동기화

### DIFF
--- a/src/admin/pages/promotion/Promotion.tsx
+++ b/src/admin/pages/promotion/Promotion.tsx
@@ -6,16 +6,22 @@ import AdminCarousel from "@admin/pages/promotion/components/AdminCarousel/Admin
 import AdminBanner from "@admin/pages/promotion/components/AdminBanner/AdminBanner";
 import { useGetCarouselPresignedUrl } from "@apis/domains/files/queries";
 import { usePutS3Upload } from "@apis/domains/files/queries";
-import { CarouselPresignedResponse } from "@apis/domains/files/api";
 import { updateCarousel } from "@apis/domains/admins/api";
 import { useModal } from "@hooks";
+
+interface PendingCarouselUpload {
+  fileName: string;
+  objectUrl: string;
+}
+
+const isBlobUrl = (url?: string) => url?.startsWith("blob:") ?? false;
 
 const Promotion = () => {
   const { openAlert } = useModal();
   const [tab, setTab] = useState("carousel");
 
   const [carouselData, setCarouselData] = useState([]);
-  const [carouselImage, setCarouselImages] = useState<string[]>([]); // presigned 보낼 state
+  const [carouselUploads, setCarouselUploads] = useState<PendingCarouselUpload[]>([]);
   const [initPromoNum, setInitPromoNum] = useState<number[]>([]); // 초기 promotionId
 
   const handleTab = (value) => {
@@ -29,115 +35,111 @@ const Promotion = () => {
   const saveCarouselData = (value) => {
     setCarouselData(value);
 
-    const tempPresigned = carouselData?.map((item, index) => {
-      if (item.promotionPhoto?.indexOf("amazonaws") === -1) {
-        return `carousel-${index + 1}-${new Date().getTime()}`;
-      }
-    });
-
-    const filtered = tempPresigned.filter((element) => element !== undefined);
-
-    setCarouselImages(filtered);
+    const timestamp = Date.now();
+    setCarouselUploads(
+      value.flatMap((item, index) =>
+        isBlobUrl(item.promotionPhoto)
+          ? [{ fileName: `carousel-${index + 1}-${timestamp}`, objectUrl: item.promotionPhoto }]
+          : []
+      )
+    );
   };
 
-  const params = { carouselImages: carouselImage };
+  const params = { carouselImages: carouselUploads.map(({ fileName }) => fileName) };
 
-  const { data, refetch } = useGetCarouselPresignedUrl(params);
-  const { mutate } = usePutS3Upload();
+  const { refetch } = useGetCarouselPresignedUrl(params);
+  const { mutateAsync: uploadToS3 } = usePutS3Upload();
 
   // 캐러셀  저장
   const handleCarouselSave = async () => {
-    const { data, isSuccess } = await refetch();
+    try {
+      const uploadedImageKeys = new Map<string, string>();
 
-    if (isSuccess) {
-      const extractUrls = (data: CarouselPresignedResponse) => {
-        return Object.values(data.data.carouselPresignedUrls).map(
-          (url) => (url as string).split("?")[0]
-        );
-      };
+      if (carouselUploads.length > 0) {
+        const { data, isSuccess } = await refetch();
+        if (!isSuccess || !data) {
+          throw new Error("캐러셀 이미지 업로드 URL을 발급하지 못했습니다.");
+        }
 
-      const S3Urls = extractUrls(data);
-
-      const files = carouselData
-        .filter((item) => item.promotionPhoto && item.promotionPhoto.includes("blob"))
-        .map((item) => item.promotionPhoto);
-
-      try {
         await Promise.all(
-          S3Urls.map(async (url, index) => {
-            const file = files[index];
+          carouselUploads.map(async ({ fileName, objectUrl }) => {
+            const upload = data.data.carouselPresignedUploads[fileName];
+            if (!upload) {
+              throw new Error("캐러셀 이미지 업로드 정보를 찾을 수 없습니다.");
+            }
 
-            const response = await fetch(file);
+            const response = await fetch(objectUrl);
+            if (!response.ok) {
+              throw new Error("캐러셀 이미지 파일을 읽지 못했습니다.");
+            }
+
             const blob = await response.blob();
-            const newFile = new File([blob], `fileName-${new Date()}`, { type: blob.type });
+            if (!blob.type.startsWith("image/")) {
+              throw new Error("이미지 파일만 업로드할 수 있습니다.");
+            }
 
-            return mutate({ url, file: newFile });
+            const file = new File([blob], fileName, { type: blob.type });
+            const uploadResponse = await uploadToS3({ url: upload.uploadUrl, file });
+            if (!uploadResponse) {
+              throw new Error("캐러셀 이미지 업로드에 실패했습니다.");
+            }
+
+            uploadedImageKeys.set(objectUrl, upload.imageKey);
           })
         );
-
-        let idxCnt = 0;
-
-        const tempCarouselData = carouselData.map((item) => {
-          if (item.promotionPhoto?.indexOf("amazonaws") === -1) {
-            idxCnt += 1;
-            return { ...item, promotionPhoto: S3Urls[idxCnt - 1] };
-          }
-          return item;
-        });
-
-        const carouselNum = ["ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN"];
-
-        const formData = {
-          carousels: tempCarouselData.map((item, index) => {
-            const { promotionPhoto, promotionId, ...rest } = item;
-
-            const carouselItem = {
-              ...rest,
-              type: initPromoNum.indexOf(item.promotionId) === -1 ? "generate" : "modify",
-              carouselNumber: carouselNum[index],
-              newImageUrl: item.promotionPhoto,
-            };
-
-            // promotionId가 initPromoNum에 없을 때 (새로 생성되었을 때)만 추가
-            if (initPromoNum.indexOf(item.promotionId) === -1) {
-              return carouselItem;
-            }
-            return { ...carouselItem, promotionId: item.promotionId };
-          }),
-        };
-
-        const allValid = formData.carousels.every(
-          (item) => item.newImageUrl !== null && item.redirectUrl !== null
-        );
-
-        console.log(formData);
-
-        if (allValid && formData.carousels.length !== 0) {
-          const res = await updateCarousel(formData);
-          console.log(res);
-          await console.log(formData);
-
-          await openAlert({
-            title: "캐러셀 수정이 완료되었습니다.",
-            okCallback: () => {
-              location.reload();
-            },
-          });
-        } else {
-          formData.carousels.forEach((item) => {
-            if (!item.newImageUrl && !item.redirectUrl) {
-              openAlert({ title: "정보가 없는 캐러셀은 삭제해 주세요." });
-            } else if (!item.newImageUrl) {
-              openAlert({ title: "모든 이미지를 삽입해 주세요." });
-            } else if (!item.redirectUrl) {
-              openAlert({ title: "모든 링크를 삽입해 주세요." });
-            }
-          });
-        }
-      } catch (err) {
-        console.error("Error during file upload or carousel update:", err);
-        openAlert({ title: "캐러셀 수정 혹은 이미지 저장을 실패했습니다.\n 다시 시도해주세요." });
       }
+
+      const tempCarouselData = carouselData.map((item) => ({
+        ...item,
+        promotionPhoto: uploadedImageKeys.get(item.promotionPhoto) ?? item.promotionPhoto,
+      }));
+
+      const carouselNum = ["ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN"];
+
+      const formData = {
+        carousels: tempCarouselData.map((item, index) => {
+          const { promotionPhoto, promotionId, ...rest } = item;
+
+          const carouselItem = {
+            ...rest,
+            type: initPromoNum.indexOf(item.promotionId) === -1 ? "generate" : "modify",
+            carouselNumber: carouselNum[index],
+            newImageUrl: item.promotionPhoto,
+          };
+
+          if (initPromoNum.indexOf(item.promotionId) === -1) {
+            return carouselItem;
+          }
+          return { ...carouselItem, promotionId: item.promotionId };
+        }),
+      };
+
+      const allValid = formData.carousels.every(
+        (item) => item.newImageUrl !== null && item.redirectUrl !== null
+      );
+
+      if (allValid && formData.carousels.length !== 0) {
+        await updateCarousel(formData);
+
+        await openAlert({
+          title: "캐러셀 수정이 완료되었습니다.",
+          okCallback: () => {
+            location.reload();
+          },
+        });
+      } else {
+        formData.carousels.forEach((item) => {
+          if (!item.newImageUrl && !item.redirectUrl) {
+            openAlert({ title: "정보가 없는 캐러셀은 삭제해 주세요." });
+          } else if (!item.newImageUrl) {
+            openAlert({ title: "모든 이미지를 삽입해 주세요." });
+          } else if (!item.redirectUrl) {
+            openAlert({ title: "모든 링크를 삽입해 주세요." });
+          }
+        });
+      }
+    } catch {
+      openAlert({ title: "캐러셀 수정 혹은 이미지 저장을 실패했습니다.\n 다시 시도해주세요." });
     }
   };
 

--- a/src/admin/pages/promotion/components/AdminCarousel/AdminCarousel.tsx
+++ b/src/admin/pages/promotion/components/AdminCarousel/AdminCarousel.tsx
@@ -26,17 +26,12 @@ const AdminCarousel = ({ saveCarouselData, saveCarouselNum }) => {
 
   useEffect(() => {
     setCarouselList(data?.promotionList);
+    saveCarouselData(data?.promotionList ?? []);
     saveCarouselNum(
       data?.promotionList.map((item) => {
         return item.promotionId;
-      })
+      }) ?? []
     );
-
-    console.log(data?.promotionList, [
-      data?.promotionList.map((item) => {
-        return item.promotionId;
-      }),
-    ]);
   }, [data]);
 
   const addCarousel = () => {
@@ -51,6 +46,7 @@ const AdminCarousel = ({ saveCarouselData, saveCarouselNum }) => {
     const updatedCarouselList = [...carouselList, newCarousel];
 
     setCarouselList(updatedCarouselList);
+    saveCarouselData(updatedCarouselList);
   };
 
   const deleteCarousel = (idx: number) => {

--- a/src/apis/domains/files/api.ts
+++ b/src/apis/domains/files/api.ts
@@ -88,7 +88,13 @@ export const putS3ImageUpload = async ({ url, file }: PutImageUploadParams) => {
 export interface CarouselPresignedResponse {
   data: {
     carouselPresignedUrls: ImageInterface;
+    carouselPresignedUploads: Record<string, CarouselPresignedUpload>;
   };
+}
+
+export interface CarouselPresignedUpload {
+  uploadUrl: string;
+  imageKey: string;
 }
 
 export interface GetCarouselPresignedUrlParams {
@@ -97,7 +103,7 @@ export interface GetCarouselPresignedUrlParams {
 
 export const getCarouselPresignedUrl = async (
   params: GetCarouselPresignedUrlParams
-): Promise<CarouselPresignedResponse | null> => {
+): Promise<CarouselPresignedResponse> => {
   try {
     const paramsWithEmptyArrays = {
       ...params,
@@ -127,7 +133,6 @@ export const getCarouselPresignedUrl = async (
 
     return response.data;
   } catch (error) {
-    console.error("error", error);
-    return null;
+    throw error;
   }
 };

--- a/src/typings/api/schema/index.ts
+++ b/src/typings/api/schema/index.ts
@@ -1759,6 +1759,13 @@ export interface components {
       carouselPresignedUrls?: {
         [key: string]: string;
       };
+      carouselPresignedUploads?: {
+        [key: string]: components["schemas"]["CarouselPresignedUploadResponse"];
+      };
+    };
+    CarouselPresignedUploadResponse: {
+      uploadUrl?: string;
+      imageKey?: string;
     };
     SuccessResponseCarouselPresignedUrlFindAllResponse: {
       /** Format: int32 */


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #521

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 리팩토링

## ✅ Key Changes

1. `carouselPresignedUploads[파일명]`의 `uploadUrl`과 `imageKey` 타입을 반영했습니다.
2. S3 PUT에는 서명된 `uploadUrl` 원문을 사용하고, PUT 완료를 `mutateAsync`로 기다립니다.
3. 캐러셀 저장 요청에는 S3 URL이 아닌 서버가 발급한 `imageKey`를 `newImageUrl`으로 전달합니다.
4. 기존 CDN 이미지와 신규 `blob:` 이미지를 구분하고, 초기·추가 캐러셀 상태를 부모 저장 상태와 동기화했습니다.

## 📢 To Reviewers

- BEAT-SERVER #564 배포 후 동작하는 계약입니다. 서버 PR과 함께 반영해 주세요.
- 프로젝트 전체 `yarn lint`는 ESLint 9에서 제거된 `--ext` 옵션 때문에 현재 실행되지 않습니다. 변경 파일은 직접 ESLint 실행으로 오류가 없는 것을 확인했습니다.

## 📸 스크린샷

- 관리자 API 계약 및 업로드 제어 흐름 변경으로 생략합니다.

## 🔗 참고 자료

- TEAM-BEAT/BEAT-SERVER#564