### PR TITLE
[Fix/#524] 카카오맵 legacy appkey를 신규 키로 교체

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-HHZWCY4574"></script>
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f4b73490dbec6c62c45107b45cc7ba84&libraries=services,clusterer,drawing"></script>
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=068647d512fd0a6d6126f98eacf00ddc&libraries=services,clusterer,drawing"></script>
 
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #524

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. `index.html`에 하드코딩된 카카오맵 JavaScript appkey를 legacy 키(`f4b73...`)에서 현재 팀 BEAT 카카오 앱의 정식 JavaScript 키(`068647d5...`)로 교체
2. legacy 키는 `dev.beatlive.kr` 도메인이 SDK 도메인 화이트리스트에 등록되어 있지 않아, dev 환경에서 `/gig-register` 진입 시 `MapInput` 렌더링 중 `TypeError: Cannot read properties of undefined (reading 'maps')`로 화면이 깨지는 문제가 있었음
3. 신규 키는 `dev.beatlive.kr`, `www.beatlive.kr`, `beatlive.kr` 도메인 등록 및 카카오맵(OPEN_MAP_AND_LOCAL) 서비스 활성화를 완료한 상태로, dev/main 두 referer 모두에서 `dapi.kakao.com/v2/maps/sdk.js` 요청이 200으로 정상 응답하는 것을 확인함
4. 저장소 전체(`git grep`, git 워킹 트리)에서 legacy appkey 잔존 여부를 재검색하여 `index.html` 외 다른 위치에는 없음을 확인

## 📢 To Reviewers

- 신규 키 교체 후 배포 도메인이 추가될 경우, 카카오 디벨로퍼스 콘솔의 JavaScript 키 > "JS SDK 도메인"에도 함께 등록해야 합니다.
- appkey가 여전히 `index.html`에 하드코딩되어 있습니다. 후속으로 환경변수 분리가 필요하다면 별도 이슈로 논의가 필요합니다.

## 📸 스크린샷

- 변경 없음 (설정값 교체)

## 🔗 참고 자료

- 기존 legacy 키 도입: PR #448