### PR TITLE
[Fix/#528] 무료·미입금 예매 관리자 삭제 정책 보완

### DIFF
--- a/src/constants/bookingStatus.ts
+++ b/src/constants/bookingStatus.ts
@@ -16,7 +16,14 @@ export const bookingStatusText: Record<BookingStatus, string> = {
   [BOOKING_STATUS.REFUND_REQUESTED]: "환불 요청",
 };
 
-export const DELETABLE_BOOKING_STATUSES = [BOOKING_STATUS.BOOKING_CANCELLED] as const;
+export const DELETABLE_BOOKING_STATUSES = {
+  PAID: [BOOKING_STATUS.CHECKING_PAYMENT, BOOKING_STATUS.BOOKING_CANCELLED],
+  FREE: [
+    BOOKING_STATUS.CHECKING_PAYMENT,
+    BOOKING_STATUS.BOOKING_CONFIRMED,
+    BOOKING_STATUS.BOOKING_CANCELLED,
+  ],
+} as const;
 
 export type bookingStatusTypes = keyof typeof bookingStatusText;
 

--- a/src/constants/bookingStatus.ts
+++ b/src/constants/bookingStatus.ts
@@ -16,15 +16,6 @@ export const bookingStatusText: Record<BookingStatus, string> = {
   [BOOKING_STATUS.REFUND_REQUESTED]: "환불 요청",
 };
 
-export const DELETABLE_BOOKING_STATUSES = {
-  PAID: [BOOKING_STATUS.CHECKING_PAYMENT, BOOKING_STATUS.BOOKING_CANCELLED],
-  FREE: [
-    BOOKING_STATUS.CHECKING_PAYMENT,
-    BOOKING_STATUS.BOOKING_CONFIRMED,
-    BOOKING_STATUS.BOOKING_CANCELLED,
-  ],
-} as const;
-
 export type bookingStatusTypes = keyof typeof bookingStatusText;
 
 export interface DefaultDepositProps {

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -209,7 +209,7 @@ const TicketHolderList = () => {
   const handlePaymentDeleteBtn = () => {
     openConfirm({
       title: "예매자를 삭제하시겠어요?",
-      subTitle: "미입금 또는 무료 예매는 취소되며 좌석이 반환돼요. 삭제 후 복구할 수 없어요.",
+      subTitle: "한 번 삭제한 예매자 정보는 다시 복구할 수 없어요.",
       okText: "삭제하기",
       noText: "아니요",
       okCallback: () => {

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -209,7 +209,7 @@ const TicketHolderList = () => {
   const handlePaymentDeleteBtn = () => {
     openConfirm({
       title: "예매자를 삭제하시겠어요?",
-      subTitle: "한 번 삭제한 예매자 정보는 다시 복구할 수 없어요.",
+      subTitle: "미입금 또는 무료 예매는 취소되며 좌석이 반환돼요. 삭제 후 복구할 수 없어요.",
       okText: "삭제하기",
       noText: "아니요",
       okCallback: () => {
@@ -297,7 +297,7 @@ const TicketHolderList = () => {
       case "DELETE":
         setFilterList({
           scheduleNumber: [],
-          bookingStatus: [...DELETABLE_BOOKING_STATUSES],
+          bookingStatus: [...DELETABLE_BOOKING_STATUSES[data?.ticketPrice === 0 ? "FREE" : "PAID"]],
         });
         break;
       default:

--- a/src/pages/ticketholderlist/TicketHolderList.tsx
+++ b/src/pages/ticketholderlist/TicketHolderList.tsx
@@ -27,7 +27,6 @@ import SelectedChips from "./components/selectedChips/SelectedChips";
 import { convertingBookingStatus } from "@constants/convertingBookingStatus";
 import { IconCheck } from "@assets/svgs";
 import Toast from "@components/commons/toast/Toast";
-import { DELETABLE_BOOKING_STATUSES } from "@constants/bookingStatus";
 import NonExistent from "./components/nonExistent/NonExistent.";
 import { getUA, isChrome } from "react-device-detect";
 import { useToastHandler } from "@hooks";
@@ -102,8 +101,12 @@ const TicketHolderList = () => {
     filterList
   );
 
-  const paymentData =
+  const retrievedPaymentData =
     debouncedQuery.length >= 2 ? (searchData?.bookingList ?? []) : (data?.bookingList ?? []);
+  const paymentData =
+    status === "DELETE"
+      ? retrievedPaymentData.filter(({ deletable }) => deletable)
+      : retrievedPaymentData;
 
   const { openConfirm, closeConfirm } = useModal();
   const [checkedBookingId, setCheckedBookingId] = useState<number[]>([]);
@@ -297,7 +300,7 @@ const TicketHolderList = () => {
       case "DELETE":
         setFilterList({
           scheduleNumber: [],
-          bookingStatus: [...DELETABLE_BOOKING_STATUSES[data?.ticketPrice === 0 ? "FREE" : "PAID"]],
+          bookingStatus: [],
         });
         break;
       default:

--- a/src/typigs/ai/schea/index.ts
+++ b/src/typigs/ai/schea/index.ts
@@ -1064,11 +1064,10 @@ export interface components {
       /** @enum {string} */
       bookingStatus?: "CHECKING_PAYMENT" | "BOOKING_CONFIRMED" | "BOOKING_CANCELLED";
       scheduleNumber?: string;
+      deletable?: boolean;
     };
     TicketRetrieveResponse: {
       performanceTitle?: string;
-      /** Format: int32 */
-      ticketPrice?: number;
       /** Format: int32 */
       totalScheduleCount?: number;
       bookingList?: components["schemas"]["TicketDetail"][];

--- a/src/typigs/ai/schea/index.ts
+++ b/src/typigs/ai/schea/index.ts
@@ -1068,6 +1068,8 @@ export interface components {
     TicketRetrieveResponse: {
       performanceTitle?: string;
       /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
       totalScheduleCount?: number;
       bookingList?: components["schemas"]["TicketDetail"][];
     };

--- a/src/typings/api/schema/index.ts
+++ b/src/typings/api/schema/index.ts
@@ -1403,6 +1403,8 @@ export interface components {
       performanceTitle?: string;
       performanceTeamName?: string;
       /** Format: int32 */
+      ticketPrice?: number;
+      /** Format: int32 */
       totalScheduleCount?: number;
       /** Format: int32 */
       totalPerformanceTicketCount?: number;

--- a/src/typings/api/schema/index.ts
+++ b/src/typings/api/schema/index.ts
@@ -1398,12 +1398,11 @@ export interface components {
       bankName?: string;
       accountNumber?: string;
       accountHolder?: string;
+      deletable?: boolean;
     };
     TicketRetrieveResponse: {
       performanceTitle?: string;
       performanceTeamName?: string;
-      /** Format: int32 */
-      ticketPrice?: number;
       /** Format: int32 */
       totalScheduleCount?: number;
       /** Format: int32 */


### PR DESCRIPTION
## 📌 관련 이슈번호

- Related to #528

## 🎟️ PR 유형

- [ ] 새 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

1. **관리자 삭제 대상 보완**
   - 서버가 예매 당시 결제 금액과 상태로 계산한 `deletable` 값에 따라 삭제 대상을 표시합니다.
   - 유료 확정 예매와 환불 요청 예매는 삭제 대상에서 제외합니다.
2. **기존 UI·API 유지**
   - 관리자 메뉴와 삭제 API를 추가하지 않고 기존 삭제 기능을 유지합니다.
   - 현재 공연 가격을 이용한 클라이언트 정책 분기를 제거했습니다.
3. **기존 안내 문구 유지**
   - 삭제 확인 모달의 기존 복구 불가 안내 문구를 유지합니다.

> 예매자·관리자 상태 문구는 기존 문구를 그대로 유지합니다.

## 🧪 검증

- `yarn tsc --noEmit`
- 변경 파일 ESLint
- `git diff --check`

## 📢 To Reviewers

- 서버 PR TEAM-BEAT/BEAT-SERVER#572와 함께 반영해야 합니다.
- 삭제 가능 여부의 최종 판단은 서버가 담당합니다.
- 유료 확정 예매와 환불 요청 예매는 삭제 대상에 노출하지 않습니다.
